### PR TITLE
Copy Klipper macro for toolhead_stage users

### DIFF
--- a/install.py
+++ b/install.py
@@ -885,6 +885,17 @@ def main() -> None:
         config_yaml = generate_middleware_config(scanner_config, middleware_config)
         install_middleware(config_yaml)
 
+        # Copy Klipper macro for toolhead_stage users
+        if middleware_config.get("setup_type") == "toolhead_stage":
+            klipper_cfg_src = os.path.join(MIDDLEWARE_DIR, "middleware", "klipper", "spoolsense.cfg")
+            klipper_cfg_dst = os.path.expanduser("~/printer_data/config/spoolsense.cfg")
+            if os.path.exists(klipper_cfg_src):
+                shutil.copy2(klipper_cfg_src, klipper_cfg_dst)
+                print(f"  {C.GREEN}✓{C.RESET} Klipper macro copied to {klipper_cfg_dst}")
+                print(f"\n  {C.YELLOW}Important:{C.RESET} Add this line to your printer.cfg:")
+                print(f"    [include spoolsense.cfg]")
+                print(f"  Then restart Klipper.\n")
+
     # ── Done ──────────────────────────────────────────────────────────────────
     print("")
     print(f"{C.GREEN}══════════════════════════════════════════")


### PR DESCRIPTION
## Summary

When the user selects `toolhead_stage` setup, the installer now copies `spoolsense.cfg` (ASSIGN_SPOOL macro) to `~/printer_data/config/` and reminds them to add `[include spoolsense.cfg]` to printer.cfg.

## Test plan

- [ ] Run installer with toolhead_stage → verify file copied and message shown
- [ ] Run installer with other setup types → verify no copy attempted