### PR TITLE
feat: add keypad and Moonraker URL prompts to installer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,14 +12,14 @@ reviews:
     base_branches:
       - ".*"
   instructions: |
-  Python CLI installer for SpoolSense (scanner firmware + middleware).
-  Single-file script (install.py) that runs on Raspberry Pi and laptops.
+    Python CLI installer for SpoolSense (scanner firmware + middleware).
+    Single-file script (install.py) that runs on Raspberry Pi and laptops.
 
-  ## Project-specific rules
+    ## Project-specific rules
 
-  - All functions must have type hints and docstrings
-  - User input must be validated before use (validate_* functions)
-  - Passwords must use getpass, never plain input()
-  - All external commands (esptool, git, pip) must handle FileNotFoundError
-  - sys.exit() calls must have user-friendly error messages, not raw tracebacks
-  - Support Linux (Pi), macOS, and Windows where possible
+    - All functions must have type hints and docstrings
+    - User input must be validated before use (validate_* functions)
+    - Passwords must use getpass, never plain input()
+    - All external commands (esptool, git, pip) must handle FileNotFoundError
+    - sys.exit() calls must have user-friendly error messages, not raw tracebacks
+    - Support Linux (Pi), macOS, and Windows where possible

--- a/install.py
+++ b/install.py
@@ -246,6 +246,13 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     print(f"\n{C.CYAN}── Optional Hardware ──────────────────{C.RESET}\n")
     lcd_on = ask_yesno("16x2 I2C LCD display attached?", default=False)
     led_on = ask_yesno("Status LED attached?", default=True)
+    keypad_on = ask_yesno("3x4 matrix keypad attached?", default=False)
+
+    print(f"\n{C.CYAN}── Printer Integration ────────────────{C.RESET}\n")
+    moonraker_url = ""
+    if ask_yesno("Klipper / Moonraker printer?", default=False):
+        moonraker_url = ask("Moonraker URL", default="http://localhost:7125",
+                            validate=validate_url)
 
     return {
         "board": board,
@@ -261,6 +268,8 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
         "auto_mode": int(auto_mode),
         "lcd_on": 1 if lcd_on else 0,
         "led_on": 1 if led_on else 0,
+        "keypad_on": 1 if keypad_on else 0,
+        "moonraker_url": moonraker_url,
     }
 
 
@@ -347,6 +356,8 @@ def generate_nvs_csv(config: Dict[str, Union[str, int]]) -> str:
         f"auto_mode,data,u8,{config['auto_mode']}",
         f"lcd_on,data,u8,{config['lcd_on']}",
         f"led_on,data,u8,{config['led_on']}",
+        f"keypad_on,data,u8,{config['keypad_on']}",
+        f"moonraker_url,data,string,{config['moonraker_url']}",
     ]
     return "\n".join(lines) + "\n"
 

--- a/nvs_keys.csv
+++ b/nvs_keys.csv
@@ -12,3 +12,5 @@ spoolman_url,data,string,Spoolman base URL
 auto_mode,data,u8,Automation mode: 0=Self Directed 1=Controlled by HA
 lcd_on,data,u8,LCD display enabled (1) or disabled (0)
 led_on,data,u8,Status LED enabled (1) or disabled (0)
+keypad_on,data,u8,3x4 matrix keypad enabled (1) or disabled (0)
+moonraker_url,data,string,Moonraker URL for Klipper integration (e.g. http://192.168.1.72:7125)


### PR DESCRIPTION
## Summary

- Adds "3x4 matrix keypad attached?" prompt to Optional Hardware section
- Adds "Klipper / Moonraker printer?" prompt with Moonraker URL (default `http://localhost:7125`)
- Writes `keypad_on` and `moonraker_url` to NVS partition
- Documents both keys in `nvs_keys.csv`

Companion to SpoolSense/spoolsense_scanner#46.

## Test plan

- [ ] Run installer, verify keypad prompt appears after LED prompt
- [ ] Verify Moonraker URL prompt only appears if user says Yes to Klipper
- [ ] Verify NVS CSV includes keypad_on and moonraker_url values
- [ ] Config-only mode also includes the new prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive setup prompts during installation for keypad configuration (3x4 matrix keypad)
  * Added optional Klipper/Moonraker printer integration setup

* **Style**
  * Configuration file formatting updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->