### PR TITLE
fix: show slicer integration prompt for afc_stage hybrid users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.3] - 2026-03-27
+
+### Added
+- Keypad and Moonraker URL prompts during scanner setup. Writes `keypad_on` and `moonraker_url` to NVS.
+- Slicer integration prompt now shown for `afc_stage` users with hybrid setups (toolchanger + AFC). Explains that `publish_lane_data` enables ASSIGN_SPOOL macro watcher for direct toolheads alongside AFC lanes.
+
+---
+
 ## [1.2.2] - 2026-03-27
 
 ### Added

--- a/install.py
+++ b/install.py
@@ -320,13 +320,18 @@ def collect_middleware_config() -> Dict[str, Union[str, List[str]]]:
     moonraker_url = ask("Moonraker URL", default="http://localhost", validate=validate_url)
 
     # Lane data publishing — for slicer integration (Orca Slicer, etc.)
-    # Only relevant for setups without AFC/Happy Hare handling lane data
     publish_lane_data = False
-    if setup_type not in ("afc_stage", "afc_lane"):
+    if setup_type == "afc_stage":
         print(f"\n  {C.YELLOW}Slicer integration:{C.RESET} Slicers like Orca Slicer can auto-populate")
         print("  tool colors, materials, and temps from your scanned spools.")
-        print(f"\n  AFC and Happy Hare already provide this feature. If you use")
-        print(f"  either of those, say No — they handle it for you.\n")
+        print(f"\n  AFC handles lane data for its own lanes automatically.")
+        print(f"  Enable this if you also have direct toolheads (e.g. a toolchanger")
+        print(f"  with a Box Turtle) and want slicer data for those tools too.")
+        print(f"  This also enables the ASSIGN_SPOOL macro for tool assignment.\n")
+        publish_lane_data = ask_yesno("Enable slicer integration for toolheads?", default=False)
+    elif setup_type not in ("afc_lane",):
+        print(f"\n  {C.YELLOW}Slicer integration:{C.RESET} Slicers like Orca Slicer can auto-populate")
+        print("  tool colors, materials, and temps from your scanned spools.\n")
         publish_lane_data = ask_yesno("Enable slicer integration?", default=False)
 
     return {

--- a/install.py
+++ b/install.py
@@ -324,10 +324,10 @@ def collect_middleware_config() -> Dict[str, Union[str, List[str]]]:
     if setup_type == "afc_stage":
         print(f"\n  {C.YELLOW}Slicer integration:{C.RESET} Slicers like Orca Slicer can auto-populate")
         print("  tool colors, materials, and temps from your scanned spools.")
-        print(f"\n  AFC handles lane data for its own lanes automatically.")
-        print(f"  Enable this if you also have direct toolheads (e.g. a toolchanger")
-        print(f"  with a Box Turtle) and want slicer data for those tools too.")
-        print(f"  This also enables the ASSIGN_SPOOL macro for tool assignment.\n")
+        print("\n  AFC handles lane data for its own lanes automatically.")
+        print("  Enable this if you also have direct toolheads (e.g. a toolchanger")
+        print("  with a Box Turtle) and want slicer data for those tools too.")
+        print("  This also enables the ASSIGN_SPOOL macro for tool assignment.\n")
         publish_lane_data = ask_yesno("Enable slicer integration for toolheads?", default=False)
     elif setup_type not in ("afc_lane",):
         print(f"\n  {C.YELLOW}Slicer integration:{C.RESET} Slicers like Orca Slicer can auto-populate")


### PR DESCRIPTION
## Summary

AFC users with hybrid setups (toolchanger + Box Turtle) need `publish_lane_data: true` to enable the ASSIGN_SPOOL macro watcher and lane_data writes for direct toolheads. Previously the slicer integration prompt was hidden for all AFC setups.

- `afc_stage` users now see a tailored prompt explaining the hybrid use case (toolchanger + AFC on same printer)
- `afc_lane` users still skip it (AFC handles lane data internally)
- Non-AFC setups unchanged

Companion to SpoolSense/spoolsense_middleware#33.

## Test plan

- [ ] Run installer with `afc_stage` — slicer integration prompt appears with hybrid explanation
- [ ] Run installer with `afc_lane` — slicer integration prompt does NOT appear
- [ ] Run installer with `toolchanger` — slicer integration prompt appears (unchanged behavior)
- [ ] Run installer with `single` — slicer integration prompt appears (unchanged behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup wizard now prompts afc_stage users specifically about enabling slicer integration for toolheads; other setups see a generic slicer-integration prompt. Lane-data publishing is set based on responses (afc_lane remains unprompted).
  * New interactive prompts for keypad and Moonraker URL during scanner setup; these settings are persisted.

* **Documentation**
  * Changelog updated with a new release entry describing the above installer and prompt changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->