### PR TITLE
fix: fail clearly on missing deps or old Python

### DIFF
--- a/install.py
+++ b/install.py
@@ -676,13 +676,19 @@ def install_middleware(config_yaml: str) -> None:
     print("  Installing Python dependencies...")
     req_file = os.path.join(MIDDLEWARE_DIR, "middleware", "requirements.txt")
     if os.path.exists(req_file):
-        result = subprocess.run([sys.executable, "-m", "pip", "install", "--quiet",
-                                 "--break-system-packages", "-r", req_file],
-                                capture_output=True, text=True)
+        try:
+            result = subprocess.run([sys.executable, "-m", "pip", "install", "--quiet",
+                                     "--break-system-packages", "-r", req_file],
+                                    capture_output=True, text=True, timeout=300)
+        except subprocess.TimeoutExpired:
+            print(f"  {C.RED}✗ pip install timed out after 5 minutes{C.RESET}")
+            print(f"    Try manually: pip3 install -r {req_file}")
+            sys.exit(1)
         if result.returncode != 0:
             print(f"  {C.RED}✗ Failed to install Python dependencies{C.RESET}")
-            if result.stderr:
-                print(f"    {result.stderr.strip()}")
+            output = result.stderr.strip() if result.stderr else result.stdout.strip()
+            if output:
+                print(f"    {output}")
             print(f"    Try manually: pip3 install -r {req_file}")
             sys.exit(1)
         print("  ✓ Dependencies installed")

--- a/install.py
+++ b/install.py
@@ -676,10 +676,21 @@ def install_middleware(config_yaml: str) -> None:
     print("  Installing Python dependencies...")
     req_file = os.path.join(MIDDLEWARE_DIR, "middleware", "requirements.txt")
     if os.path.exists(req_file):
-        subprocess.run([sys.executable, "-m", "pip", "install", "--quiet",
-                        "--break-system-packages", "-r", req_file],
-                       capture_output=True)
-    print("  ✓ Dependencies installed")
+        result = subprocess.run([sys.executable, "-m", "pip", "install", "--quiet",
+                                 "--break-system-packages", "-r", req_file],
+                                capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"  {C.RED}✗ Failed to install Python dependencies{C.RESET}")
+            if result.stderr:
+                print(f"    {result.stderr.strip()}")
+            print(f"    Try manually: pip3 install -r {req_file}")
+            sys.exit(1)
+        print("  ✓ Dependencies installed")
+    else:
+        print(f"  {C.RED}✗ requirements.txt not found at {req_file}{C.RESET}")
+        print("    The middleware repository may be incomplete. Try deleting")
+        print(f"    {MIDDLEWARE_DIR} and running the installer again.")
+        sys.exit(1)
 
     # Write config
     config_path = os.path.join(MIDDLEWARE_DIR, "middleware", "config.yaml")
@@ -738,6 +749,13 @@ WantedBy=multi-user.target
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> None:
+    # Python version check — middleware uses features that require 3.9+
+    if sys.version_info < (3, 9):
+        print(f"\n  {C.RED}✗ Python 3.9 or newer is required.{C.RESET}")
+        print(f"    You have: Python {sys.version_info.major}.{sys.version_info.minor}")
+        print("    Install a newer Python or use pyenv.")
+        sys.exit(1)
+
     print(f"""{C.CYAN}{C.BOLD}
   ____                    _ ____
  / ___| _ __   ___   ___ | / ___|  ___ _ __  ___  ___

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,15 @@ if ! command -v python3 &>/dev/null; then
     exit 1
 fi
 
+# Check Python version >= 3.9
+if ! python3 -c "import sys; exit(0) if sys.version_info >= (3,9) else exit(1)" 2>/dev/null; then
+    PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+    echo "ERROR: Python 3.9 or newer is required."
+    echo "  You have: Python ${PY_VER}"
+    echo "  Install a newer Python or use pyenv."
+    exit 1
+fi
+
 # Check git
 if ! command -v git &>/dev/null; then
     echo "ERROR: git is required but not installed."


### PR DESCRIPTION
## Summary

- **Missing requirements.txt**: now errors with instructions instead of silently skipping and printing a checkmark
- **pip install failure**: shows error and stderr instead of claiming success
- **Python < 3.9**: fails early with a clear message and suggestion to use pyenv

Fixes #8. Companion fix: SpoolSense/spoolsense_middleware requirements.txt added.

## Test plan

- [ ] Run installer with missing requirements.txt — clear error shown
- [ ] Run installer with Python 3.8 — version check fails with message
- [ ] Run installer normally — deps install and service starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Installation now provides clearer error messages when dependency installation fails, including suggested troubleshooting commands.
  * Added validation to detect missing configuration files and exit gracefully with informative guidance instead of proceeding.

* **Chores**
  * Added Python 3.9+ runtime version requirement validation at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->