### PR TITLE
feat: NFC reader selection prompt

### DIFF
--- a/install.py
+++ b/install.py
@@ -248,7 +248,8 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     led_on = ask_yesno("Status LED attached?", default=True)
     keypad_on = ask_yesno("3x4 matrix keypad attached?", default=False)
     nfc_reader = ask("NFC reader model", default="pn5180",
-                     validate=lambda v: v.lower() in ("pn5180", "pn532"))
+                     validate=lambda v: None if v.lower() in ("pn5180", "pn532")
+                     else "Must be pn5180 or pn532")
     nfc_reader = nfc_reader.lower()
 
     print(f"\n{C.CYAN}── Printer Integration ────────────────{C.RESET}\n")

--- a/install.py
+++ b/install.py
@@ -963,8 +963,12 @@ def main() -> None:
         print("")
         if mode in ("both", "scanner"):
             print(f"  Scanner:    {C.CYAN}http://spoolsense.local{C.GREEN}")
+            print(f"  Device ID:  Shown on the landing page (needed for middleware config)")
         if mode in ("both", "middleware"):
             print(f"  Middleware: {C.CYAN}systemctl status spoolsense{C.GREEN}")
+            print(f"  Config:     {C.CYAN}~/SpoolSense/middleware/config.yaml{C.GREEN}")
+            print(f"  {C.YELLOW}Remember:{C.RESET}{C.GREEN} Replace YOUR_DEVICE_ID in config.yaml with")
+            print(f"  the device ID from {C.CYAN}http://spoolsense.local{C.GREEN}")
     print("")
     print(f"  Tap a spool to test.{C.RESET}")
     print(f"{C.GREEN}══════════════════════════════════════════{C.RESET}")

--- a/install.py
+++ b/install.py
@@ -247,6 +247,9 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     lcd_on = ask_yesno("16x2 I2C LCD display attached?", default=False)
     led_on = ask_yesno("Status LED attached?", default=True)
     keypad_on = ask_yesno("3x4 matrix keypad attached?", default=False)
+    nfc_reader = ask("NFC reader model", default="pn5180",
+                     validate=lambda v: v.lower() in ("pn5180", "pn532"))
+    nfc_reader = nfc_reader.lower()
 
     print(f"\n{C.CYAN}── Printer Integration ────────────────{C.RESET}\n")
     moonraker_url = ""
@@ -269,6 +272,7 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
         "lcd_on": 1 if lcd_on else 0,
         "led_on": 1 if led_on else 0,
         "keypad_on": 1 if keypad_on else 0,
+        "nfc_reader": nfc_reader,
         "moonraker_url": moonraker_url,
     }
 
@@ -362,6 +366,7 @@ def generate_nvs_csv(config: Dict[str, Union[str, int]]) -> str:
         f"lcd_on,data,u8,{config['lcd_on']}",
         f"led_on,data,u8,{config['led_on']}",
         f"keypad_on,data,u8,{config['keypad_on']}",
+        f"nfc_reader,data,string,{config['nfc_reader']}",
         f"moonraker_url,data,string,{config['moonraker_url']}",
     ]
     return "\n".join(lines) + "\n"

--- a/nvs_keys.csv
+++ b/nvs_keys.csv
@@ -13,4 +13,5 @@ auto_mode,data,u8,Automation mode: 0=Self Directed 1=Controlled by HA
 lcd_on,data,u8,LCD display enabled (1) or disabled (0)
 led_on,data,u8,Status LED enabled (1) or disabled (0)
 keypad_on,data,u8,3x4 matrix keypad enabled (1) or disabled (0)
+nfc_reader,data,string,NFC reader model: pn5180 (default) or pn532
 moonraker_url,data,string,Moonraker URL for Klipper integration (e.g. http://printer.local:7125)


### PR DESCRIPTION
## Summary
- Add `nfc_reader` prompt to hardware config section (pn5180/pn532, default pn5180)
- Write to NVS as string key for runtime reader selection in scanner firmware v1.5.9+

## Context
Companion to SpoolSense/spoolsense_scanner#48 — PN532 NFC reader support. Both readers are compiled into the same firmware binary; NVS selects which one initializes at boot.

## Test plan
- [ ] Run installer, verify NFC reader prompt appears after keypad question
- [ ] Confirm "pn5180" default works (just press Enter)
- [ ] Confirm "pn532" accepted and written to NVS CSV
- [ ] Confirm invalid input (e.g. "foo") is rejected by validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NFC reader model option during device setup with two supported models (pn5180 or pn532); input is case-insensitive, defaults to pn5180, and is saved to device configuration.
  * The selected NFC reader is now persisted in device storage for later use.
  * Device configuration export now includes the NFC reader setting.
  * CLI completion help now includes middleware config path and instruction to replace YOUR_DEVICE_ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->