### PR TITLE
fix: create destination directory before copying spoolsense.cfg (#13)

### DIFF
--- a/install.py
+++ b/install.py
@@ -944,6 +944,7 @@ def main() -> None:
             klipper_cfg_src = os.path.join(MIDDLEWARE_DIR, "middleware", "klipper", "spoolsense.cfg")
             klipper_cfg_dst = os.path.expanduser("~/printer_data/config/spoolsense.cfg")
             if os.path.exists(klipper_cfg_src):
+                os.makedirs(os.path.dirname(klipper_cfg_dst), exist_ok=True)
                 shutil.copy2(klipper_cfg_src, klipper_cfg_dst)
                 print(f"  {C.GREEN}✓{C.RESET} Klipper macro copied to {klipper_cfg_dst}")
                 print(f"\n  {C.YELLOW}Important:{C.RESET} Add this line to your printer.cfg:")


### PR DESCRIPTION
## Summary

- `shutil.copy2` crashes with `FileNotFoundError` if `~/printer_data/config/` does not exist
- Added `os.makedirs(os.path.dirname(klipper_cfg_dst), exist_ok=True)` before the copy

## Test plan

- [ ] Run installer with `toolhead_stage` setup on a machine without `~/printer_data/config/` — should create the directory and copy successfully
- [ ] Run on a machine where the directory already exists — `exist_ok=True` ensures no error

Fixes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an installer issue where installation would fail if the configuration directory did not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->