### PR TITLE
fix: validate firmware download size before flashing (#20)

### DIFF
--- a/install.py
+++ b/install.py
@@ -441,10 +441,15 @@ def fetch_latest_release() -> dict:
         sys.exit(1)
 
 
-def download_asset(release: dict, suffix: str) -> bytes:
-    """Download a firmware asset matching the given suffix."""
-    # Match spoolsense_scanner_<suffix>.bin specifically, not partitions or other files
-    target_name = f"spoolsense_scanner_{suffix}.bin"
+def download_asset(release: dict, name: str = "", suffix: str = "") -> bytes:
+    """Download a release asset by exact name or firmware suffix.
+
+    Args:
+        release: GitHub release dict with 'assets' list
+        name: Exact asset filename (e.g. 'bootloader_esp32dev.bin')
+        suffix: Firmware suffix — expands to 'spoolsense_scanner_{suffix}.bin'
+    """
+    target_name = name or f"spoolsense_scanner_{suffix}.bin"
     for asset in release.get("assets", []):
         if asset["name"] == target_name:
             url = asset["browser_download_url"]
@@ -461,7 +466,7 @@ def download_asset(release: dict, suffix: str) -> bytes:
                 sys.exit(1)
             return data
 
-    print(f"\n  ✗ No firmware binary found for '{suffix}' in release {release.get('tag_name', '?')}")
+    print(f"\n  ✗ Asset '{target_name}' not found in release {release.get('tag_name', '?')}")
     print("    Available assets:")
     for asset in release.get("assets", []):
         print(f"      {asset['name']}")
@@ -855,44 +860,14 @@ def main() -> None:
         release = fetch_latest_release()
         board_key = scanner_config["board"]
         _, _, fw_suffix, _, _ = BOARDS[board_key]
-        firmware_bin = download_asset(release, fw_suffix)
+        firmware_bin = download_asset(release, suffix=fw_suffix)
         print(f"  {C.GREEN}✓{C.RESET} Firmware downloaded ({len(firmware_bin)} bytes)")
 
-        # Download matching bootloader
-        bootloader_name = f"bootloader_{fw_suffix}.bin"
-        bootloader_bin = None
-        for asset in release.get("assets", []):
-            if asset["name"] == bootloader_name:
-                expected = asset.get("size", 0)
-                print(f"  Downloading {bootloader_name}...")
-                with urllib.request.urlopen(asset["browser_download_url"], timeout=30) as resp:
-                    bootloader_bin = resp.read()
-                if expected and len(bootloader_bin) != expected:
-                    print(f"\n  ✗ Bootloader download incomplete: got {len(bootloader_bin)} bytes, expected {expected}")
-                    sys.exit(1)
-                print(f"  {C.GREEN}✓{C.RESET} Bootloader downloaded ({len(bootloader_bin)} bytes)")
-                break
-        if bootloader_bin is None:
-            print(f"\n  ✗ Bootloader '{bootloader_name}' not found in release.")
-            sys.exit(1)
+        bootloader_bin = download_asset(release, name=f"bootloader_{fw_suffix}.bin")
+        print(f"  {C.GREEN}✓{C.RESET} Bootloader downloaded ({len(bootloader_bin)} bytes)")
 
-        # Download matching partition table
-        partitions_name = f"partitions_{fw_suffix}.bin"
-        partitions_bin = None
-        for asset in release.get("assets", []):
-            if asset["name"] == partitions_name:
-                expected = asset.get("size", 0)
-                print(f"  Downloading {partitions_name}...")
-                with urllib.request.urlopen(asset["browser_download_url"], timeout=30) as resp:
-                    partitions_bin = resp.read()
-                if expected and len(partitions_bin) != expected:
-                    print(f"\n  ✗ Partition table download incomplete: got {len(partitions_bin)} bytes, expected {expected}")
-                    sys.exit(1)
-                print(f"  {C.GREEN}✓{C.RESET} Partition table downloaded ({len(partitions_bin)} bytes)")
-                break
-        if partitions_bin is None:
-            print(f"\n  ✗ Partition table '{partitions_name}' not found in release.")
-            sys.exit(1)
+        partitions_bin = download_asset(release, name=f"partitions_{fw_suffix}.bin")
+        print(f"  {C.GREEN}✓{C.RESET} Partition table downloaded ({len(partitions_bin)} bytes)")
 
         # Generate NVS config partition
         print("  Generating NVS config partition...")


### PR DESCRIPTION
## Summary
- After downloading firmware, bootloader, and partition table, compare file size against GitHub release API `size` field
- Catches truncated downloads from flaky WiFi, disk full, or timeouts before flashing
- Graceful degradation: if GitHub API doesn't include size (size=0), skip the check

## Test Plan
- [ ] Normal download — size matches, flashes normally
- [ ] Simulated truncated download — exits with clear error message before flashing

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added download integrity checks to ensure release assets are fully downloaded; the process now fails with clear error messages if a download is incomplete.

* **Improvements**
  * Firmware downloads are now more flexible (accepting either exact file names or firmware suffixes) and report the computed target filename in errors.
  * Consolidated download handling for bootloader/partition files for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->