### PR TITLE
feat: ESP32-C3-DevKitM-1 board support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.6] - 2026-05-09
+
+### Added
+- **ESP32-C3 board support** — `ESP32-C3-DevKitM-1 (4MB)` now selectable in the scanner board prompt. Matches the existing `esp32c3` PlatformIO env in the scanner firmware. Bootloader offset `0x0` (newer-ROM behavior, same as S3 family).
+
+---
+
 ## [1.2.5] - 2026-04-06
 
 ### Added

--- a/spoolsense_installer/config.py
+++ b/spoolsense_installer/config.py
@@ -14,6 +14,7 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     board = ask_choice("Scanner board:", {
         "esp32dev": "ESP32-WROOM DevKit (4MB) — most common",
         "esp32s3zero": "ESP32-S3-Zero by Waveshare (4MB)",
+        "esp32c3": "ESP32-C3-DevKitM-1 (4MB)",
         "esp32s3devkitc": "ESP32-S3-DevKitC-1-N16R8 (16MB + 8MB PSRAM)",
         "other": "Other / not sure",
     })

--- a/spoolsense_installer/constants.py
+++ b/spoolsense_installer/constants.py
@@ -10,10 +10,11 @@ MOONRAKER_CONF_PATH = os.path.expanduser("~/printer_data/config/moonraker.conf")
 
 SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Bootloader offset: esp32 uses 0x1000, esp32s3 uses 0x0 (rev2 bootloader in ROM)
+# Bootloader offset: original esp32 uses 0x1000; esp32s3/c3 use 0x0 (newer ROM bootloader)
 BOARDS = {
     "esp32dev": ("ESP32-WROOM DevKit (4MB)", "esp32", "esp32dev", 4 * 1024 * 1024, 0x1000),
     "esp32s3zero": ("ESP32-S3-Zero by Waveshare (4MB)", "esp32s3", "esp32s3zero", 4 * 1024 * 1024, 0x0),
+    "esp32c3": ("ESP32-C3-DevKitM-1 (4MB)", "esp32c3", "esp32c3", 4 * 1024 * 1024, 0x0),
     "esp32s3devkitc": ("ESP32-S3-DevKitC-1-N16R8 (16MB+8MB PSRAM)", "esp32s3", "esp32s3devkitc", 16 * 1024 * 1024, 0x0),
 }
 


### PR DESCRIPTION
## Summary

- Adds `esp32c3` to the installer's `BOARDS` map (`constants.py`) and to the scanner board choice prompt (`config.py`).
- Display name: `ESP32-C3-DevKitM-1 (4MB)`. Chip ID and firmware suffix both `esp32c3`. Bootloader offset `0x0` (matches the S3 family — newer ROM bootloader).
- CHANGELOG bumped to `1.2.6`.

The scanner firmware already builds the `esp32c3` env and the release workflow publishes `spoolsense_scanner_esp32c3.bin`, `bootloader_esp32c3.bin`, and `partitions_esp32c3.bin` per release, so no scanner-side change is needed — the existing `download_asset(release, suffix="esp32c3")` path resolves against current and future releases.

## Why

C3 was missing from the installer despite being a built and released firmware target. Users on C3 hardware had no path through the interactive installer.

## Test plan

- [ ] Run the installer end-to-end against an ESP32-C3-DevKitM-1
- [ ] Confirm the new "ESP32-C3-DevKitM-1 (4MB)" choice appears in the board prompt
- [ ] Confirm chip detection passes (`Chip is ESP32-C3...`) and flash size check passes against a 4MB part
- [ ] Confirm flashing succeeds with bootloader at `0x0`, partitions at `0x8000`, NVS at `0x9000`, app at `0x10000`
- [ ] Confirm the scanner boots and runs the C3 firmware after install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ESP32-C3-DevKitM-1 (4MB) microcontroller board, which is now available as a selectable target device in the scanner board selection menu for firmware installation and system configuration.

* **Documentation**
  * Updated bootloader offset specifications and configuration details for different ESP32 board variants to ensure proper firmware installation across all supported boards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpoolSense/spoolsense-installer/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->