### PR TITLE
chore: bump installer version to 1.2.6

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 """
 SpoolSense Installer — interactive CLI for scanner firmware + middleware setup.
 


### PR DESCRIPTION
## Summary
Bumps `__version__` in `install.py` from `1.2.5` to `1.2.6`. Should have been part of #31; landing as a separate one-line follow-up.

## Changes
- `install.py`: `__version__ = "1.2.5"` → `"1.2.6"`

## How to Test
Run `python3 install.py --version` (or inspect the banner) and confirm it reports `1.2.6`.

## Checklist
- [x] Tested on Raspberry Pi OS
- [x] All install modes still work (Scanner + Middleware / Scanner only / Middleware only)