### PR TITLE
Week 1 catch-up: fail-closed flashing, macros for all modes, honest summary, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, dev]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # 3.9 is the installer's minimum supported version
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tooling
+        run: pip install pytest flake8
+
+      - name: Lint (syntax errors and undefined names)
+        run: flake8 install.py spoolsense_installer tests --select=E9,F63,F7,F82 --show-source
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ollama_suggestions.md
 .cocoindex_code/
 .mex/
 .DS_Store
+30dayplan.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.3.0] - Unreleased
+
+### Added
+- **Robust Spoolman extra-field creation** (#17, #33) — waits for Spoolman to come up (~45s budget), retries transient failures with backoff, never silently skips a field, and prints a prominent summary with copy-paste `curl` commands for anything that failed. New `--setup-fields` flag re-runs just the field creation. *(shipped earlier on `main`, previously unlogged)*
+- **Klipper macros installed for every setup type** (#27, #30) — `spoolsense.cfg` (ASSIGN_SPOOL/UPDATE_TAG) is now copied for all setups, not just `toolhead_stage`; without it, automatic filament deduction never fires. `spoolman_macros.cfg` is copied for direct-toolhead setups and `toolhead_macros_example.cfg` for multi-tool setups (existing copies are never overwritten). The installer now prints PRINT_END/UPDATE_TAG guidance.
+- **Honest install summary** — the final message now lists every step with its actual outcome (✓/⚠/✗) instead of always claiming "SpoolSense is installed!". Failed systemd creation, skipped config writes, unwritten Moonraker config, and pending YOUR_DEVICE_ID edits are called out explicitly.
+- **CI** — GitHub Actions now runs the test suite and critical lint checks on every PR (Python 3.9 and 3.12).
+- Installer version is now shown in the banner.
+
+### Fixed
+- **Chip verification fails closed** — flashing now aborts if `esptool flash-id` exits non-zero, times out, or its output can't be parsed (previously verification was silently skipped and flashing proceeded). Chip family matching is exact: selecting `esp32dev` with an ESP32-S3 connected is now rejected (substring matching previously let it through).
+- **Flash timeout handled** — a hung flash now exits with guidance instead of a traceback; timeout raised from 2 to 5 minutes for 16MB boards.
+- **Removed the dead `mqtt_prefix` prompt/NVS key** — the pre-built firmware's MQTT topic prefix is compile-time (`spoolsense`) and the NVS key was never read; prompting for it falsely implied custom prefixes work.
+- Declining the `config.yaml` overwrite prompt no longer skips systemd service creation.
+- The manual systemd setup instruction no longer points at a temp file that was already deleted.
+- `nvs_keys.csv` documentation regenerated to match the generator (namespace row fixed, `tft_driver` added, dead `mqtt_prefix` removed).
+
+### Changed
+- README: corrected Python requirement (3.9+, was "3.6+"), documented all four supported boards (ESP32-C3 and S3-DevKitC-1 were missing), the Config-only mode, `--setup-fields`, and the Web Flasher alternative.
+- ESP32-C3 board label aligned with spoolsense.org: "ESP32-C3 SuperMini / DevKitM-1".
+
+---
+
 ## [1.2.6] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Interactive CLI installer for the [SpoolSense](https://github.com/SpoolSense) ec
 curl -sL https://raw.githubusercontent.com/SpoolSense/spoolsense-installer/main/install.sh -o /tmp/install.sh && bash /tmp/install.sh
 ```
 
+Prefer a browser? You can flash the scanner firmware without installing anything using the [Web Flasher](https://spoolsense.org/installation/web-flasher/) (Chrome/Edge), then run this installer with "Middleware only" on your printer host.
+
 ## How It Works
 
 The installer asks a series of questions (WiFi, MQTT, board type, etc.) and then:
@@ -23,7 +25,23 @@ The installer asks a series of questions (WiFi, MQTT, board type, etc.) and then
    - **Toolchanger shared scanner** (`toolhead_stage`) — one scanner for all toolheads (klipper-toolchanger)
    - **Toolchanger per-toolhead** (`toolhead`) — one scanner per tool
    - **Single toolhead** (`single`) — one scanner, one extruder
-3. **Spoolman** — Optionally creates extra fields in Spoolman (`nfc_id`, `tag_format`, `aspect`, `dry_temp`, `dry_time_hours`) needed for full tag data tracking
+3. **Klipper macros** — Copies the macros your setup needs to `~/printer_data/config/`: `spoolsense.cfg` (ASSIGN_SPOOL/UPDATE_TAG, all setups), `spoolman_macros.cfg` (direct-toolhead setups), and `toolhead_macros_example.cfg` (multi-tool setups). Add `UPDATE_TAG` to your `PRINT_END` macro for automatic filament tracking.
+4. **Spoolman** — Optionally creates extra fields in Spoolman (`nfc_id`, `tag_format`, `aspect`, `dry_temp`, `dry_time_hours`) needed for full tag data tracking, and offers to add the `[spoolman]` section to `moonraker.conf`
+
+### Install modes
+
+- **Scanner + Middleware** — everything in one pass (recommended, run on the printer host)
+- **Scanner only** — flash the ESP32 (e.g. from a laptop)
+- **Middleware only** — printer-host setup without flashing (also the right choice after using the Web Flasher)
+- **Config only** — for source builds: writes `spoolsense_nvs.csv`/`.bin` to the current directory so you can flash config without reflashing firmware
+
+### Extra flags
+
+```bash
+python3 install.py --setup-fields [--spoolman-url http://spoolman.local:7912]
+```
+
+Re-creates just the required Spoolman extra fields (useful if Spoolman wasn't running during the initial install).
 
 
 ## Recommended Setup
@@ -44,6 +62,8 @@ After installation, open `http://spoolsense.local` in your browser to retrieve y
 |-------|-------|--------|
 | ESP32-WROOM DevKit | 4MB | Tested |
 | ESP32-S3-Zero (Waveshare) | 4MB | Tested |
+| ESP32-C3 SuperMini / DevKitM-1 | 4MB | Tested |
+| ESP32-S3-DevKitC-1-N16R8 | 16MB + 8MB PSRAM | Tested |
 
 Other boards: compile from source via [PlatformIO](https://github.com/SpoolSense/spoolsense_scanner).
 
@@ -65,7 +85,7 @@ The installer verifies the connected chip type and flash size before flashing to
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.9+
 - git
 - USB cable (for scanner flashing)
 - Network access (to download firmware and clone repos)

--- a/install.py
+++ b/install.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-__version__ = "1.2.6"
 """
 SpoolSense Installer — interactive CLI for scanner firmware + middleware setup.
 
@@ -13,17 +12,19 @@ the middleware (choose "Middleware only").
 Note: SpoolSense middleware must run on the printer host.
 """
 
+__version__ = "1.3.0"
+
 import argparse
 import os
 import sys
 import tempfile
 
 from spoolsense_installer.constants import C, BOARDS, MIDDLEWARE_DIR
-from spoolsense_installer.ui import ask_choice, ask_yesno, ask, validate_url
+from spoolsense_installer.ui import ask_choice, ask, validate_url
 from spoolsense_installer.config import collect_scanner_config, collect_middleware_config, collect_middleware_mqtt_settings
 from spoolsense_installer.nvs import generate_nvs_csv, generate_nvs_bin
 from spoolsense_installer.firmware import fetch_latest_release, download_asset, detect_usb_port, verify_flash, flash_firmware
-from spoolsense_installer.middleware import generate_config as generate_middleware_config, install as install_middleware
+from spoolsense_installer.middleware import generate_config as generate_middleware_config, install as install_middleware, copy_klipper_macros
 from spoolsense_installer.spoolman import setup_extra_fields, setup_moonraker_spoolman, print_failed_fields_summary
 
 
@@ -95,46 +96,106 @@ def run_config_only(scanner_config: dict) -> None:
     print(f"\n  Flash with: esptool write-flash 0x9000 {bin_path}")
 
 
-def run_middleware_install(scanner_config: dict, middleware_config: dict) -> None:
-    """Generate middleware config, install repo, create systemd service."""
+def run_middleware_install(scanner_config: dict, middleware_config: dict) -> list:
+    """Generate middleware config, install repo, create systemd service.
+
+    Returns summary steps: a list of (label, status, detail) tuples.
+    """
     config_yaml = generate_middleware_config(scanner_config, middleware_config)
-    install_middleware(config_yaml)
+    result = install_middleware(config_yaml)
 
-    # Copy Klipper macro if toolchanger setup
+    steps = [("Middleware repo + dependencies", "ok", MIDDLEWARE_DIR)]
+    config_path = os.path.join(MIDDLEWARE_DIR, "config.yaml")
+    if result["config"] == "written":
+        steps.append(("config.yaml written", "ok", config_path))
+        steps.append(("Replace YOUR_DEVICE_ID in config.yaml", "warn",
+                      "device ID shown at http://spoolsense.local"))
+    else:
+        steps.append(("config.yaml kept (existing file untouched)", "skip", config_path))
+
+    if result["service"] is True:
+        steps.append(("systemd service (spoolsense.service)", "ok", "enabled on boot"))
+    elif result["service"] is False:
+        steps.append(("systemd service (spoolsense.service)", "fail", "see manual setup above"))
+    else:
+        steps.append(("systemd service", "skip", "not a systemd host"))
+
+    # Klipper macros — UPDATE_TAG drives filament deduction in every mode (#30)
     setup_type = middleware_config.get("setup_type", "")
-    if setup_type != "toolhead_stage":
-        return
-    macro_src = os.path.join(MIDDLEWARE_DIR, "middleware", "klipper", "spoolsense.cfg")
-    macro_dst = os.path.expanduser("~/printer_data/config/spoolsense.cfg")
-    if not os.path.exists(macro_src):
-        return
+    macro_dst = os.path.expanduser("~/printer_data/config")
     try:
-        import shutil
-        shutil.copy2(macro_src, macro_dst)
-        print(f"  {C.GREEN}✓{C.RESET} Copied spoolsense.cfg to {macro_dst}")
-        print(f"  {C.YELLOW}Note:{C.RESET} Add [include spoolsense.cfg] to your printer.cfg")
-    except Exception as e:
-        print(f"  {C.YELLOW}!{C.RESET} Could not copy Klipper macro: {e}")
+        macro_results = copy_klipper_macros(setup_type)
+    except OSError as e:
+        print(f"  {C.YELLOW}!{C.RESET} Could not copy Klipper macros: {e}")
+        macro_results = {}
+        steps.append(("Klipper macros", "fail", str(e)))
+
+    copied = [n for n, s in macro_results.items() if s == "copied"]
+    kept = [n for n, s in macro_results.items() if s == "kept-existing"]
+    missing = [n for n, s in macro_results.items() if s == "missing-source"]
+    for name in copied:
+        print(f"  {C.GREEN}✓{C.RESET} Copied {name} to {macro_dst}")
+    for name in kept:
+        print(f"  {C.DIM}−{C.RESET} Kept existing {name} (not overwritten)")
+    if copied or kept:
+        includes = ", ".join(f"[include {n}]" for n in sorted(copied + kept)
+                             if n != "toolhead_macros_example.cfg")
+        print(f"\n  {C.YELLOW}Klipper setup:{C.RESET} add to your printer.cfg: {includes}")
+        print(f"  For automatic filament tracking, add {C.BOLD}UPDATE_TAG{C.RESET} to your")
+        print("  PRINT_END macro — the middleware deducts usage and writes it")
+        print("  back to the spool's NFC tag on the next scan.")
+        if "toolhead_macros_example.cfg" in copied + kept:
+            print(f"  Multi-tool: adapt toolhead_macros_example.cfg into your T0-Tn macros.")
+        steps.append(("Klipper macros installed", "ok", ", ".join(sorted(copied + kept))))
+        steps.append(("Add UPDATE_TAG to your PRINT_END macro", "warn",
+                      "enables automatic filament tracking"))
+    if missing:
+        steps.append(("Klipper macros missing from middleware checkout", "warn",
+                      ", ".join(sorted(missing))))
+    return steps
 
 
-def print_completion_message(mode: str, scanner_config: dict) -> None:
-    """Print the final success message with next steps."""
-    print(f"\n{C.GREEN}{'═' * 42}")
-    print(f"  SpoolSense is installed!")
+# Summary rendering: ok/warn/fail/skip per step, header reflects the worst outcome
+_STEP_ICONS = {
+    "ok": f"{C.GREEN}✓{C.RESET}",
+    "warn": f"{C.YELLOW}⚠{C.RESET}",
+    "fail": f"{C.RED}✗{C.RESET}",
+    "skip": f"{C.DIM}−{C.RESET}",
+}
+
+
+def print_completion_message(mode: str, scanner_config: dict, steps: list) -> None:
+    """Print a truthful install summary: every step with its actual outcome."""
+    failed = any(status == "fail" for _, status, _ in steps)
+    warned = any(status == "warn" for _, status, _ in steps)
+    if failed:
+        color, title = C.RED, "Install finished with errors — see below"
+    elif warned:
+        color, title = C.YELLOW, "SpoolSense is installed — action needed"
+    else:
+        color, title = C.GREEN, "SpoolSense is installed!"
+
+    print(f"\n{color}{'═' * 42}")
+    print(f"  {title}")
     print(f"{'═' * 42}{C.RESET}\n")
 
+    for label, status, detail in steps:
+        icon = _STEP_ICONS.get(status, " ")
+        line = f"  {icon} {label}"
+        if detail:
+            line += f" {C.DIM}— {detail}{C.RESET}"
+        print(line)
+
+    print()
     if mode in ("both", "scanner"):
         hostname = scanner_config.get("hostname", "spoolsense")
         print(f"  Scanner:    http://{hostname}.local")
     if mode in ("both", "middleware"):
-        print(f"  Middleware:  systemctl status spoolsense")
+        print(f"  Middleware: systemctl status spoolsense")
         print(f"  Config:     {MIDDLEWARE_DIR}/config.yaml")
     if mode == "config":
         print(f"  NVS binary: spoolsense_nvs.bin (flash with esptool)")
-
-    print(f"\n{C.RED}{C.BOLD}  ⚠  IMPORTANT: Replace YOUR_DEVICE_ID in the middleware config")
-    print(f"     with your scanner's device ID.")
-    print(f"     Find it at http://spoolsense.local (shown on landing page).{C.RESET}\n")
+    print()
 
 
 # ── Entry point ──────────────────────────────────────────────────────────────
@@ -189,7 +250,8 @@ def main() -> None:
   ___) | |_) | (_) | (_) | |___) |  __/ | | \\__ \\  __/
  |____/| .__/ \\___/ \\___/|_|____/ \\___|_| |_|___/\\___|
        |_|{C.RESET}
-{C.DIM}          NFC Filament Intelligence for 3D Printers{C.RESET}
+{C.DIM}          NFC Filament Intelligence for 3D Printers
+          Installer v{__version__}{C.RESET}
     """)
 
     print(f"  {C.GREEN}RECOMMENDED:{C.RESET} Run from your printer host (Raspberry Pi)")
@@ -218,21 +280,41 @@ def main() -> None:
         middleware_config = collect_middleware_config()
 
     failed_fields = []
+    steps = []
     if mode in ("both", "scanner"):
         failed_fields = run_scanner_install(scanner_config)
+        steps.append(("Scanner firmware flashed", "ok",
+                      BOARDS[scanner_config["board"]][0]))
+        if scanner_config.get("spoolman_on") and scanner_config.get("spoolman_url"):
+            if failed_fields:
+                steps.append(("Spoolman extra fields", "fail",
+                              f"{len(failed_fields)} field(s) not created — see below"))
+            else:
+                steps.append(("Spoolman extra fields", "ok", ""))
+        else:
+            steps.append(("Spoolman extra fields", "skip", "Spoolman disabled"))
 
     if mode == "config":
         run_config_only(scanner_config)
+        steps.append(("NVS config generated", "ok", "spoolsense_nvs.bin"))
 
     if mode in ("both", "middleware"):
-        run_middleware_install(scanner_config, middleware_config)
+        steps.extend(run_middleware_install(scanner_config, middleware_config))
 
     # Moonraker Spoolman config (independent of mode)
     spoolman_url = scanner_config.get("spoolman_url") or ""
     if scanner_config.get("spoolman_on") and spoolman_url:
-        setup_moonraker_spoolman(spoolman_url)
+        moonraker_status = setup_moonraker_spoolman(spoolman_url)
+        steps.append({
+            "added": ("Moonraker [spoolman] config", "warn", "restart Moonraker to apply"),
+            "exists": ("Moonraker [spoolman] config", "ok", "already configured"),
+            "declined": ("Moonraker [spoolman] config", "skip", "declined"),
+            "missing-conf": ("Moonraker [spoolman] config", "warn",
+                             "moonraker.conf not found — add manually"),
+            "failed": ("Moonraker [spoolman] config", "fail", "could not write moonraker.conf"),
+        }[moonraker_status])
 
-    print_completion_message(mode, scanner_config)
+    print_completion_message(mode, scanner_config, steps)
 
     # Print last so a field-creation failure is the final thing the user sees.
     print_failed_fields_summary(spoolman_url, failed_fields)

--- a/nvs_keys.csv
+++ b/nvs_keys.csv
@@ -1,19 +1,19 @@
 key,type,encoding,description
-wifi_ssid,namespace,,SpoolSense config namespace
+spoolsense,namespace,,SpoolSense config namespace
 wifi_ssid,data,string,WiFi network name (max 32 chars)
 wifi_pass,data,string,WiFi password
 mqtt_host,data,string,MQTT broker IP or hostname
 mqtt_port,data,u16,MQTT broker port (default 1883)
 mqtt_user,data,string,MQTT username
 mqtt_pass,data,string,MQTT password
-mqtt_prefix,data,string,MQTT topic prefix (default spoolsense)
 spoolman_on,data,u8,Spoolman enabled (1) or disabled (0)
 spoolman_url,data,string,Spoolman base URL
 auto_mode,data,u8,Automation mode: 0=Self Directed 1=Controlled by HA
 lcd_on,data,u8,LCD display enabled (1) or disabled (0)
+tft_on,data,u8,TFT display enabled (1) or disabled (0)
+tft_driver,data,string,TFT driver: st7789 (square) or gc9a01 (round)
 led_on,data,u8,Status LED enabled (1) or disabled (0)
 keypad_on,data,u8,3x4 matrix keypad enabled (1) or disabled (0)
-tft_on,data,u8,TFT display enabled (1) or disabled (0)
 nfc_reader,data,string,NFC reader model: pn5180 (default) or pn532
 hostname,data,string,mDNS/WiFi hostname (default spoolsense; max 32 chars; lowercase alphanum + hyphens)
 moonraker_url,data,string,Moonraker URL for Klipper integration (e.g. http://printer.local:7125)

--- a/spoolsense_installer/config.py
+++ b/spoolsense_installer/config.py
@@ -14,7 +14,7 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     board = ask_choice("Scanner board:", {
         "esp32dev": "ESP32-WROOM DevKit (4MB) — most common",
         "esp32s3zero": "ESP32-S3-Zero by Waveshare (4MB)",
-        "esp32c3": "ESP32-C3-DevKitM-1 (4MB)",
+        "esp32c3": "ESP32-C3 SuperMini / DevKitM-1 (4MB)",
         "esp32s3devkitc": "ESP32-S3-DevKitC-1-N16R8 (16MB + 8MB PSRAM)",
         "other": "Other / not sure",
     })
@@ -47,7 +47,8 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     mqtt_port = ask("MQTT port", default=1883, validate=validate_port)
     mqtt_user = ask("MQTT username", default="")
     mqtt_pass = ask("MQTT password", password=True, default="")
-    mqtt_prefix = ask("MQTT topic prefix", default="spoolsense")
+    # No topic-prefix prompt: the pre-built firmware publishes under a
+    # compile-time "spoolsense" prefix (UserConfig.h) — it is not configurable.
 
     spoolman_on = ask_yesno("Enable Spoolman?", default=True)
     spoolman_url = ""
@@ -94,7 +95,6 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
         "mqtt_port": int(mqtt_port),
         "mqtt_user": mqtt_user,
         "mqtt_pass": mqtt_pass,
-        "mqtt_prefix": mqtt_prefix,
         "spoolman_on": 1 if spoolman_on else 0,
         "spoolman_url": spoolman_url,
         "auto_mode": int(auto_mode),

--- a/spoolsense_installer/constants.py
+++ b/spoolsense_installer/constants.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOARDS = {
     "esp32dev": ("ESP32-WROOM DevKit (4MB)", "esp32", "esp32dev", 4 * 1024 * 1024, 0x1000),
     "esp32s3zero": ("ESP32-S3-Zero by Waveshare (4MB)", "esp32s3", "esp32s3zero", 4 * 1024 * 1024, 0x0),
-    "esp32c3": ("ESP32-C3-DevKitM-1 (4MB)", "esp32c3", "esp32c3", 4 * 1024 * 1024, 0x0),
+    "esp32c3": ("ESP32-C3 SuperMini / DevKitM-1 (4MB)", "esp32c3", "esp32c3", 4 * 1024 * 1024, 0x0),
     "esp32s3devkitc": ("ESP32-S3-DevKitC-1-N16R8 (16MB+8MB PSRAM)", "esp32s3", "esp32s3devkitc", 16 * 1024 * 1024, 0x0),
 }
 

--- a/spoolsense_installer/firmware.py
+++ b/spoolsense_installer/firmware.py
@@ -160,8 +160,11 @@ def verify_flash(port: Optional[str], board_key: str) -> bool:
         sys.exit(1)
     print(f"  Chip: {detected_display} ✓")
 
-    # Flash size varies: 4MB minimum for most, 16MB for S3-DevKitC (PSRAM)
-    flash_match = re.search(r"(\d+)\s*MB", output)
+    # Flash size varies: 4MB minimum for most, 16MB for S3-DevKitC (PSRAM).
+    # Anchor on the labeled line — S3 output lists "Embedded PSRAM 8MB" in
+    # Features BEFORE "Detected flash size: 16MB", and a bare first-match
+    # would read the PSRAM size and falsely reject valid boards.
+    flash_match = re.search(r"flash size:?\s*(\d+)\s*MB", output, re.IGNORECASE)
     if not flash_match:
         print(f"\n  ✗ Could not determine flash size from esptool output.")
         print("    Refusing to flash an unverified device.")

--- a/spoolsense_installer/firmware.py
+++ b/spoolsense_installer/firmware.py
@@ -13,6 +13,9 @@ from typing import Optional
 
 from .constants import BOARDS, C, GITHUB_API
 
+# 16MB boards (S3-DevKitC) can exceed the old 2-minute budget at low baud rates
+FLASH_TIMEOUT = 300
+
 
 def fetch_latest_release() -> dict:
     """Fetch latest release info from GitHub API."""
@@ -100,7 +103,11 @@ def detect_usb_port() -> Optional[str]:
 
 
 def verify_flash(port: Optional[str], board_key: str) -> bool:
-    """Verify the connected chip matches the selected board and has sufficient flash."""
+    """Verify the connected chip matches the selected board and has sufficient flash.
+
+    Fails CLOSED: if the chip or flash size cannot be positively confirmed, the
+    installer aborts rather than flashing an unverified device.
+    """
     board_name, expected_chip, _, min_flash, _ = BOARDS[board_key]
     print(f"\n  Verifying chip...")
 
@@ -110,38 +117,65 @@ def verify_flash(port: Optional[str], board_key: str) -> bool:
     cmd.append("flash-id")
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
-    except (FileNotFoundError, OSError):
-        cmd[0] = sys.executable
-        cmd.insert(1, "-m")
-        cmd.insert(2, "esptool")
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        except (FileNotFoundError, OSError):
+            cmd[0] = sys.executable
+            cmd.insert(1, "-m")
+            cmd.insert(2, "esptool")
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except subprocess.TimeoutExpired:
+        print(f"\n  ✗ Chip verification timed out — the device is not responding.")
+        print("    Unplug and reconnect the USB cable, then try again.")
+        print("    If using an ESP32-S3/C3, hold BOOT while connecting.")
+        sys.exit(1)
 
     output = result.stdout + result.stderr
 
-    # Prevent flashing wrong board variant (e.g. esp32s3 firmware on esp32 chip)
-    chip_match = re.search(r"Chip is (ESP32[^\s]*)", output)
-    if chip_match:
-        detected_chip = chip_match.group(1).lower().replace("-", "")
-        if expected_chip not in detected_chip:
-            print(f"\n  ✗ Chip mismatch!")
-            print(f"    Selected board: {board_name} (expects {expected_chip})")
-            print(f"    Detected chip:  {chip_match.group(1)}")
-            print(f"    Please select the correct board type and try again.")
-            sys.exit(1)
-        print(f"  Chip: {chip_match.group(1)} ✓")
+    if result.returncode != 0:
+        print(f"\n  ✗ Could not read chip info (esptool exited with {result.returncode}).")
+        tail = output.strip().splitlines()[-3:]
+        for line in tail:
+            print(f"    {line}")
+        print("    Check the USB cable and serial permissions, then try again.")
+        sys.exit(1)
+
+    # Prevent flashing wrong board variant (e.g. esp32s3 firmware on esp32 chip).
+    # Match the chip FAMILY exactly — substring checks would accept esp32s3 for esp32.
+    family_match = re.search(r"Chip is (ESP32(?:-S2|-S3|-C3|-C6|-H2|-P4)?)", output)
+    display_match = re.search(r"Chip is (ESP32[^\s]*)", output)
+    if not family_match:
+        print(f"\n  ✗ Could not identify the connected chip from esptool output.")
+        print("    Refusing to flash an unverified device.")
+        print("    Unplug and reconnect the USB cable, then try again.")
+        sys.exit(1)
+
+    detected_family = family_match.group(1).lower().replace("-", "")
+    detected_display = display_match.group(1) if display_match else family_match.group(1)
+    if detected_family != expected_chip:
+        print(f"\n  ✗ Chip mismatch!")
+        print(f"    Selected board: {board_name} (expects {expected_chip})")
+        print(f"    Detected chip:  {detected_display}")
+        print(f"    Please select the correct board type and try again.")
+        sys.exit(1)
+    print(f"  Chip: {detected_display} ✓")
 
     # Flash size varies: 4MB minimum for most, 16MB for S3-DevKitC (PSRAM)
     flash_match = re.search(r"(\d+)\s*MB", output)
-    if flash_match:
-        flash_bytes = int(flash_match.group(1)) * 1024 * 1024
-        if flash_bytes < min_flash:
-            print(f"\n  ✗ Flash too small!")
-            print(f"    Required: {min_flash // (1024*1024)}MB")
-            print(f"    Detected: {flash_match.group(1)}MB")
-            print(f"    This board cannot run SpoolSense firmware.")
-            sys.exit(1)
-        print(f"  Flash: {flash_match.group(1)}MB ✓")
+    if not flash_match:
+        print(f"\n  ✗ Could not determine flash size from esptool output.")
+        print("    Refusing to flash an unverified device.")
+        print("    Unplug and reconnect the USB cable, then try again.")
+        sys.exit(1)
+
+    flash_bytes = int(flash_match.group(1)) * 1024 * 1024
+    if flash_bytes < min_flash:
+        print(f"\n  ✗ Flash too small!")
+        print(f"    Required: {min_flash // (1024*1024)}MB")
+        print(f"    Detected: {flash_match.group(1)}MB")
+        print(f"    This board cannot run SpoolSense firmware.")
+        sys.exit(1)
+    print(f"  Flash: {flash_match.group(1)}MB ✓")
 
     return True
 
@@ -174,12 +208,18 @@ def flash_firmware(port: Optional[str], board_key: str, firmware_bin: bytes,
         ])
 
         try:
-            result = subprocess.run(cmd, timeout=120)
-        except (FileNotFoundError, OSError):
-            cmd[0] = sys.executable
-            cmd.insert(1, "-m")
-            cmd.insert(2, "esptool")
-            result = subprocess.run(cmd, timeout=120)
+            try:
+                result = subprocess.run(cmd, timeout=FLASH_TIMEOUT)
+            except (FileNotFoundError, OSError):
+                cmd[0] = sys.executable
+                cmd.insert(1, "-m")
+                cmd.insert(2, "esptool")
+                result = subprocess.run(cmd, timeout=FLASH_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            print(f"\n  ✗ Flashing timed out after {FLASH_TIMEOUT // 60} minutes.")
+            print("    The device may be in a bad state — power-cycle it and")
+            print("    run the installer again.")
+            sys.exit(1)
 
         if result.returncode != 0:
             print("\n  ✗ Flash failed!")

--- a/spoolsense_installer/middleware.py
+++ b/spoolsense_installer/middleware.py
@@ -48,6 +48,7 @@ moonraker_url: "{middleware_config['moonraker_url']}"
 
 low_spool_threshold: 100
 
+# Must match the scanner firmware's compile-time MQTT topic prefix
 scanner_topic_prefix: "spoolsense"
 
 scanners:
@@ -59,8 +60,57 @@ publish_lane_data: {str(middleware_config.get('publish_lane_data', False)).lower
     return config_yaml
 
 
-def install(config_yaml: str) -> None:
-    """Clone SpoolSense middleware, install deps, write config, create service."""
+# Which shipped macro files each setup type needs. spoolsense.cfg carries
+# ASSIGN_SPOOL/UPDATE_TAG — UPDATE_TAG drives filament deduction in every mode.
+# spoolman_macros.cfg (SET_ACTIVE_SPOOL) is for direct-toolhead setups; AFC
+# manages its own Spoolman state. toolhead_macros_example.cfg is a per-tool
+# template for multi-tool setups.
+_MACROS_BY_SETUP = {
+    "spoolsense.cfg": ("afc_stage", "afc_lane", "toolhead_stage", "toolchanger", "single"),
+    "spoolman_macros.cfg": ("toolhead_stage", "toolchanger", "single"),
+    "toolhead_macros_example.cfg": ("toolhead_stage", "toolchanger"),
+}
+# spoolsense.cfg is SpoolSense-owned and safe to refresh; the others are
+# templates the user edits, so an existing copy is never touched.
+_REFRESH_ON_REINSTALL = ("spoolsense.cfg",)
+
+
+def copy_klipper_macros(setup_type: str, src_dir: str = None, dst_dir: str = None) -> dict:
+    """Copy the Klipper macro files this setup type needs into the printer config dir.
+
+    Returns {filename: status} with status one of "copied", "kept-existing",
+    "missing-source". Missing sources are reported, not fatal — the middleware
+    checkout may predate a macro file.
+    """
+    if src_dir is None:
+        src_dir = os.path.join(MIDDLEWARE_DIR, "middleware", "klipper")
+    if dst_dir is None:
+        dst_dir = os.path.expanduser("~/printer_data/config")
+
+    results = {}
+    for name, setup_types in _MACROS_BY_SETUP.items():
+        if setup_type not in setup_types:
+            continue
+        src = os.path.join(src_dir, name)
+        dst = os.path.join(dst_dir, name)
+        if not os.path.exists(src):
+            results[name] = "missing-source"
+            continue
+        if os.path.exists(dst) and name not in _REFRESH_ON_REINSTALL:
+            results[name] = "kept-existing"
+            continue
+        shutil.copy2(src, dst)
+        results[name] = "copied"
+    return results
+
+
+def install(config_yaml: str) -> dict:
+    """Clone SpoolSense middleware, install deps, write config, create service.
+
+    Returns step outcomes: {"config": "written"|"kept", "service": True|False|None}
+    (service None = not attempted, e.g. non-Linux host). Fatal failures still
+    exit directly.
+    """
     print(f"\n{C.CYAN}── Installing Middleware ────────────────{C.RESET}\n")
 
     if os.path.isdir(MIDDLEWARE_DIR):
@@ -99,21 +149,26 @@ def install(config_yaml: str) -> None:
     print("  ✓ Dependencies installed")
 
     # Config lives in SpoolSense root directory
+    config_status = "written"
     config_path = os.path.join(MIDDLEWARE_DIR, "config.yaml")
     if os.path.exists(config_path):
         print(f"  ⚠  Existing config found at {config_path}")
         if not ask_yesno("  Overwrite?", default=False):
-            print("  Skipping config write.")
-            return
-    with open(config_path, "w") as f:
-        f.write(config_yaml)
-    print(f"  {C.GREEN}✓{C.RESET} Config written to {config_path}")
+            print("  Keeping existing config.")
+            config_status = "kept"
+    if config_status == "written":
+        with open(config_path, "w") as f:
+            f.write(config_yaml)
+        print(f"  {C.GREEN}✓{C.RESET} Config written to {config_path}")
 
+    service_status = None
     if platform.system() == "Linux" and shutil.which("systemctl"):
-        create_systemd_service()
+        service_status = create_systemd_service()
+
+    return {"config": config_status, "service": service_status}
 
 
-def create_systemd_service() -> None:
+def create_systemd_service() -> bool:
     """Create and enable systemd service for SpoolSense middleware."""
     # After=network-online.target ensures MQTT broker is reachable before starting
     service_content = f"""[Unit]
@@ -146,8 +201,10 @@ WantedBy=multi-user.target
         subprocess.run(["sudo", "systemctl", "enable", "spoolsense"], check=True)
         subprocess.run(["sudo", "systemctl", "restart", "spoolsense"], check=True)
         print("  ✓ SpoolSense service started and enabled on boot")
+        os.unlink(tmp_path)
+        return True
     except subprocess.CalledProcessError:
+        # Keep the tmp file — the manual-setup instruction points at it.
         print(f"{C.YELLOW}  ⚠ {C.RESET} Could not create systemd service (requires sudo)")
         print(f"     Manual setup: copy {tmp_path} to {service_path}")
-    finally:
-        os.unlink(tmp_path)
+        return False

--- a/spoolsense_installer/nvs.py
+++ b/spoolsense_installer/nvs.py
@@ -26,7 +26,6 @@ def generate_nvs_csv(config: Dict[str, Union[str, int]]) -> str:
         ("mqtt_port", "data", "u16", config["mqtt_port"]),
         ("mqtt_user", "data", "string", config["mqtt_user"]),
         ("mqtt_pass", "data", "string", config["mqtt_pass"]),
-        ("mqtt_prefix", "data", "string", config["mqtt_prefix"]),
         ("spoolman_on", "data", "u8", config["spoolman_on"]),
         ("spoolman_url", "data", "string", config["spoolman_url"]),
         ("auto_mode", "data", "u8", config["auto_mode"]),

--- a/spoolsense_installer/spoolman.py
+++ b/spoolsense_installer/spoolman.py
@@ -129,11 +129,13 @@ def print_failed_fields_summary(spoolman_url: str, failed: list) -> None:
         print(f"      -d '{payload}'\n")
 
 
-def setup_moonraker_spoolman(spoolman_url: str) -> None:
+def setup_moonraker_spoolman(spoolman_url: str) -> str:
     """Offer to add [spoolman] section to moonraker.conf if not already present.
 
     Moonraker's built-in Spoolman integration tracks filament usage in real-time
     during prints. Without this, tracking won't work for UID-only tags.
+
+    Returns one of: "added", "exists", "declined", "missing-conf", "failed".
     """
     if not os.path.exists(MOONRAKER_CONF_PATH):
         print(f"  {C.YELLOW}!{C.RESET} moonraker.conf not found at {MOONRAKER_CONF_PATH}")
@@ -141,14 +143,14 @@ def setup_moonraker_spoolman(spoolman_url: str) -> None:
         print(f"    [spoolman]")
         print(f"    server: {spoolman_url}")
         print(f"    sync_rate: 5")
-        return
+        return "missing-conf"
 
     with open(MOONRAKER_CONF_PATH, "r") as f:
         content = f.read()
 
     if re.search(r'^\[spoolman\]\s*$', content, re.MULTILINE):
         print(f"  {C.GREEN}✓{C.RESET} Moonraker Spoolman config already exists — skipping")
-        return
+        return "exists"
 
     print(f"\n  {C.YELLOW}Moonraker Spoolman Integration:{C.RESET}")
     print(f"  Moonraker can automatically track filament usage during prints")
@@ -157,7 +159,7 @@ def setup_moonraker_spoolman(spoolman_url: str) -> None:
 
     if not ask_yesno("Add [spoolman] to moonraker.conf?", default=True):
         print(f"  Skipped. You can add it manually later.")
-        return
+        return "declined"
 
     # sync_rate: 5 syncs filament usage every 5 seconds during prints
     spoolman_block = f"\n[spoolman]\nserver: {spoolman_url}\nsync_rate: 5\n"
@@ -167,11 +169,14 @@ def setup_moonraker_spoolman(spoolman_url: str) -> None:
         print(f"  {C.GREEN}✓{C.RESET} Added [spoolman] to {MOONRAKER_CONF_PATH}")
         print(f"\n  {C.YELLOW}Important:{C.RESET} Restart Moonraker for this change to take effect:")
         print(f"    sudo systemctl restart moonraker\n")
+        return "added"
     except PermissionError:
         print(f"  {C.RED}✗{C.RESET} Permission denied writing to {MOONRAKER_CONF_PATH}")
         print(f"    Add this manually:")
         print(f"    [spoolman]")
         print(f"    server: {spoolman_url}")
         print(f"    sync_rate: 5")
+        return "failed"
     except Exception as e:
         print(f"  {C.RED}✗{C.RESET} Failed to write moonraker.conf: {e}")
+        return "failed"

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -27,6 +27,17 @@ GOOD_ESP32_OUTPUT = (
     "Detected flash size: 4MB\n"
 )
 
+# Real-world S3-DevKitC output: the PSRAM size appears BEFORE the flash size.
+# Naive "first NN MB" parsing reads 8MB and falsely aborts a valid 16MB board.
+S3_DEVKITC_PSRAM_OUTPUT = (
+    "esptool v5.0\n"
+    "Chip is ESP32-S3 (QFN56) (revision v0.1)\n"
+    "Features: WiFi, BLE, Embedded PSRAM 8MB (AP_3v3)\n"
+    "Manufacturer: 20\n"
+    "Device: 4017\n"
+    "Detected flash size: 16MB\n"
+)
+
 
 class VerifyFlashTest(unittest.TestCase):
     """verify_flash must fail CLOSED: no flashing unless chip and size are confirmed."""
@@ -37,6 +48,12 @@ class VerifyFlashTest(unittest.TestCase):
 
     def test_accepts_matching_chip_and_flash(self):
         self.assertTrue(self._verify(completed(stdout=GOOD_ESP32_OUTPUT)))
+
+    def test_psram_size_not_mistaken_for_flash_size(self):
+        """S3 boards list 'Embedded PSRAM 8MB' before 'Detected flash size: 16MB' —
+        the parser must anchor on the labeled flash line, not the first MB value."""
+        self.assertTrue(self._verify(completed(stdout=S3_DEVKITC_PSRAM_OUTPUT),
+                                     board_key="esp32s3devkitc"))
 
     def test_exits_when_esptool_fails(self):
         """Non-zero esptool exit must abort, even if output happens to parse."""

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,0 +1,97 @@
+# test_firmware.py — unit tests for chip verification and flash safety behavior
+#
+# Run: python3 -m unittest discover -s tests -v
+#
+# subprocess.run is stubbed so no esptool or hardware is needed.
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from spoolsense_installer import firmware
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+GOOD_ESP32_OUTPUT = (
+    "esptool v5.0\n"
+    "Chip is ESP32-D0WD-V3 (revision v3.1)\n"
+    "Detected flash size: 4MB\n"
+)
+
+
+class VerifyFlashTest(unittest.TestCase):
+    """verify_flash must fail CLOSED: no flashing unless chip and size are confirmed."""
+
+    def _verify(self, run_result, board_key="esp32dev"):
+        with mock.patch.object(firmware.subprocess, "run", return_value=run_result):
+            return firmware.verify_flash("/dev/ttyUSB0", board_key)
+
+    def test_accepts_matching_chip_and_flash(self):
+        self.assertTrue(self._verify(completed(stdout=GOOD_ESP32_OUTPUT)))
+
+    def test_exits_when_esptool_fails(self):
+        """Non-zero esptool exit must abort, even if output happens to parse."""
+        with self.assertRaises(SystemExit):
+            self._verify(completed(returncode=2, stdout=GOOD_ESP32_OUTPUT))
+
+    def test_exits_when_chip_not_detected(self):
+        """Unparseable output must abort — never proceed unverified."""
+        with self.assertRaises(SystemExit):
+            self._verify(completed(stdout="something unexpected\n"))
+
+    def test_exits_when_flash_size_not_detected(self):
+        out = "Chip is ESP32-D0WD-V3 (revision v3.1)\nno size here\n"
+        with self.assertRaises(SystemExit):
+            self._verify(completed(stdout=out))
+
+    def test_exits_on_chip_mismatch(self):
+        out = "Chip is ESP32-S3 (QFN56)\nDetected flash size: 4MB\n"
+        with self.assertRaises(SystemExit):
+            self._verify(completed(stdout=out), board_key="esp32dev")
+
+    def test_exits_when_flash_too_small(self):
+        out = "Chip is ESP32-S3 (QFN56)\nDetected flash size: 4MB\n"
+        with self.assertRaises(SystemExit):
+            self._verify(completed(stdout=out), board_key="esp32s3devkitc")
+
+    def test_exits_cleanly_on_timeout(self):
+        """A hung esptool must produce a friendly exit, not a traceback."""
+        with mock.patch.object(
+            firmware.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd="esptool", timeout=15),
+        ):
+            with self.assertRaises(SystemExit):
+                firmware.verify_flash("/dev/ttyUSB0", "esp32dev")
+
+
+class FlashFirmwareTest(unittest.TestCase):
+    def test_exits_cleanly_on_timeout(self):
+        """A flash that exceeds the timeout must exit with a message, not a traceback."""
+        with tempfile.TemporaryDirectory() as d:
+            paths = []
+            for name in ("nvs.bin", "part.bin", "boot.bin"):
+                p = os.path.join(d, name)
+                with open(p, "wb") as f:
+                    f.write(b"\x00")
+                paths.append(p)
+
+            with mock.patch.object(
+                firmware.subprocess, "run",
+                side_effect=subprocess.TimeoutExpired(cmd="esptool", timeout=120),
+            ):
+                with self.assertRaises(SystemExit):
+                    firmware.flash_firmware("/dev/ttyUSB0", "esp32dev", b"\x00" * 16,
+                                            paths[0], paths[1], paths[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_summary.py
+++ b/tests/test_install_summary.py
@@ -1,0 +1,61 @@
+# test_install_summary.py — the final message must reflect what actually happened
+#
+# Run: python3 -m unittest discover -s tests -v
+
+import contextlib
+import io
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import install
+
+
+def strip_ansi(text):
+    return re.sub(r"\033\[[0-9;]*m", "", text)
+
+
+def render(mode="both", steps=()):
+    scanner_config = {"hostname": "spoolsense"}
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        install.print_completion_message(mode, scanner_config, list(steps))
+    return strip_ansi(buf.getvalue())
+
+
+class CompletionMessageTest(unittest.TestCase):
+    def test_all_ok_claims_success(self):
+        out = render(steps=[("Scanner firmware flashed", "ok", ""),
+                            ("Spoolman extra fields", "ok", "")])
+        self.assertIn("SpoolSense is installed!", out)
+        self.assertIn("✓ Scanner firmware flashed", out)
+
+    def test_failed_step_must_not_claim_success(self):
+        """The old installer printed "installed!" even when steps failed."""
+        out = render(steps=[("Scanner firmware flashed", "ok", ""),
+                            ("systemd service", "fail", "sudo required")])
+        self.assertNotIn("SpoolSense is installed!", out)
+        self.assertIn("✗ systemd service", out)
+        self.assertIn("sudo required", out)
+
+    def test_warn_step_flags_action_needed(self):
+        out = render(steps=[("config.yaml written", "ok", ""),
+                            ("Replace YOUR_DEVICE_ID in config.yaml", "warn", "")])
+        self.assertIn("action needed", out)
+        self.assertIn("⚠ Replace YOUR_DEVICE_ID", out)
+
+    def test_skipped_step_rendered_as_skipped(self):
+        out = render(steps=[("Spoolman extra fields", "skip", "Spoolman disabled")])
+        self.assertIn("− Spoolman extra fields", out)
+        self.assertIn("SpoolSense is installed!", out)
+
+    def test_scanner_mode_shows_device_url(self):
+        out = render(mode="scanner", steps=[("Scanner firmware flashed", "ok", "")])
+        self.assertIn("http://spoolsense.local", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,131 @@
+# test_middleware.py — unit tests for config generation and Klipper macro installation
+#
+# Run: python3 -m unittest discover -s tests -v
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from spoolsense_installer.middleware import copy_klipper_macros, generate_config
+
+ALL_SETUP_TYPES = ("afc_stage", "afc_lane", "toolhead_stage", "toolchanger", "single")
+
+MACRO_FILES = ("spoolsense.cfg", "spoolman_macros.cfg", "toolhead_macros_example.cfg")
+
+
+def make_src_dir(root):
+    """Create a fake middleware klipper/ dir with all shipped macro files."""
+    src = os.path.join(root, "klipper")
+    os.makedirs(src)
+    for name in MACRO_FILES:
+        with open(os.path.join(src, name), "w") as f:
+            f.write(f"# {name} from repo\n")
+    return src
+
+
+class CopyKlipperMacrosTest(unittest.TestCase):
+    def _copy(self, setup_type, prepare_dst=None, src_files=MACRO_FILES):
+        with tempfile.TemporaryDirectory() as root:
+            src = make_src_dir(root)
+            for name in MACRO_FILES:
+                if name not in src_files:
+                    os.unlink(os.path.join(src, name))
+            dst = os.path.join(root, "printer_config")
+            os.makedirs(dst)
+            if prepare_dst:
+                prepare_dst(dst)
+            results = copy_klipper_macros(setup_type, src_dir=src, dst_dir=dst)
+            return results, {n for n in os.listdir(dst)}
+
+    def test_spoolsense_cfg_copied_for_every_setup_type(self):
+        """UPDATE_TAG drives filament deduction in ALL modes (#30) — the macro
+        file must be installed regardless of setup type."""
+        for setup_type in ALL_SETUP_TYPES:
+            results, files = self._copy(setup_type)
+            self.assertIn("spoolsense.cfg", files,
+                          f"spoolsense.cfg missing for {setup_type}")
+            self.assertEqual(results["spoolsense.cfg"], "copied")
+
+    def test_spoolman_macros_copied_for_toolhead_modes_only(self):
+        """SET_ACTIVE_SPOOL macros are for direct-toolhead setups; AFC manages
+        its own Spoolman state (#27)."""
+        for setup_type in ("single", "toolchanger", "toolhead_stage"):
+            _, files = self._copy(setup_type)
+            self.assertIn("spoolman_macros.cfg", files, setup_type)
+        for setup_type in ("afc_stage", "afc_lane"):
+            _, files = self._copy(setup_type)
+            self.assertNotIn("spoolman_macros.cfg", files, setup_type)
+
+    def test_toolhead_example_copied_for_multi_tool_modes_only(self):
+        for setup_type in ("toolchanger", "toolhead_stage"):
+            _, files = self._copy(setup_type)
+            self.assertIn("toolhead_macros_example.cfg", files, setup_type)
+        for setup_type in ("single", "afc_stage", "afc_lane"):
+            _, files = self._copy(setup_type)
+            self.assertNotIn("toolhead_macros_example.cfg", files, setup_type)
+
+    def test_spoolsense_cfg_is_refreshed_on_reinstall(self):
+        """spoolsense.cfg is SpoolSense-owned — reinstall updates it."""
+
+        def prepare(dst):
+            with open(os.path.join(dst, "spoolsense.cfg"), "w") as f:
+                f.write("# old version\n")
+
+        with tempfile.TemporaryDirectory() as root:
+            src = make_src_dir(root)
+            dst = os.path.join(root, "printer_config")
+            os.makedirs(dst)
+            prepare(dst)
+            copy_klipper_macros("single", src_dir=src, dst_dir=dst)
+            with open(os.path.join(dst, "spoolsense.cfg")) as f:
+                self.assertIn("from repo", f.read())
+
+    def test_user_editable_macros_never_overwritten(self):
+        """spoolman_macros/toolhead_macros are templates users customize — an
+        existing copy must be left untouched."""
+        marker = "# user customized\n"
+
+        def prepare(dst):
+            for name in ("spoolman_macros.cfg", "toolhead_macros_example.cfg"):
+                with open(os.path.join(dst, name), "w") as f:
+                    f.write(marker)
+
+        with tempfile.TemporaryDirectory() as root:
+            src = make_src_dir(root)
+            dst = os.path.join(root, "printer_config")
+            os.makedirs(dst)
+            prepare(dst)
+            results = copy_klipper_macros("toolchanger", src_dir=src, dst_dir=dst)
+            for name in ("spoolman_macros.cfg", "toolhead_macros_example.cfg"):
+                with open(os.path.join(dst, name)) as f:
+                    self.assertEqual(f.read(), marker, name)
+                self.assertEqual(results[name], "kept-existing")
+
+    def test_missing_source_reported_not_fatal(self):
+        results, files = self._copy("single", src_files=("spoolsense.cfg",))
+        self.assertEqual(results["spoolsense.cfg"], "copied")
+        self.assertEqual(results["spoolman_macros.cfg"], "missing-source")
+
+
+class GenerateConfigTest(unittest.TestCase):
+    def test_topic_prefix_matches_compiled_firmware(self):
+        scanner_config = {
+            "mqtt_host": "broker", "mqtt_port": 1883,
+            "mqtt_user": "", "mqtt_pass": "", "spoolman_url": "",
+        }
+        middleware_config = {
+            "setup_type": "single",
+            "scanners": [{"action": "toolhead", "toolhead": "T0"}],
+            "moonraker_url": "http://localhost:7125",
+            "publish_lane_data": False,
+        }
+        yaml_text = generate_config(scanner_config, middleware_config)
+        self.assertIn('scanner_topic_prefix: "spoolsense"', yaml_text)
+        self.assertIn('action: "toolhead"', yaml_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nvs.py
+++ b/tests/test_nvs.py
@@ -1,0 +1,63 @@
+# test_nvs.py — unit tests for NVS partition CSV generation
+#
+# Run: python3 -m unittest discover -s tests -v
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from spoolsense_installer.nvs import generate_nvs_csv
+
+
+def make_scanner_config(**overrides):
+    """A scanner config dict as collect_scanner_config() returns it."""
+    config = {
+        "board": "esp32dev",
+        "hostname": "spoolsense",
+        "wifi_ssid": "MyWiFi",
+        "wifi_pass": "secret",
+        "mqtt_host": "192.168.1.10",
+        "mqtt_port": 1883,
+        "mqtt_user": "",
+        "mqtt_pass": "",
+        "spoolman_on": 1,
+        "spoolman_url": "http://spoolman.local:7912",
+        "auto_mode": 0,
+        "lcd_on": 0,
+        "tft_on": 0,
+        "tft_driver": "st7789",
+        "led_on": 1,
+        "keypad_on": 0,
+        "nfc_reader": "pn5180",
+        "moonraker_url": "",
+    }
+    config.update(overrides)
+    return config
+
+
+class GenerateNvsCsvTest(unittest.TestCase):
+    def test_does_not_write_dead_mqtt_prefix_key(self):
+        """The firmware never reads mqtt_prefix (its topic prefix is compile-time);
+        the installer must not prompt for it or write it to NVS."""
+        csv_text = generate_nvs_csv(make_scanner_config())
+        self.assertNotIn("mqtt_prefix", csv_text)
+
+    def test_namespace_and_expected_keys_present(self):
+        csv_text = generate_nvs_csv(make_scanner_config())
+        self.assertIn("spoolsense,namespace,,", csv_text)
+        for key in ("wifi_ssid", "wifi_pass", "mqtt_host", "mqtt_port", "mqtt_user",
+                    "mqtt_pass", "spoolman_on", "spoolman_url", "auto_mode", "lcd_on",
+                    "tft_on", "tft_driver", "led_on", "keypad_on", "nfc_reader",
+                    "hostname", "moonraker_url"):
+            self.assertIn(f"{key},data,", csv_text)
+
+    def test_values_with_commas_are_escaped(self):
+        """A comma in the SSID must not corrupt the CSV row structure (#19)."""
+        csv_text = generate_nvs_csv(make_scanner_config(wifi_ssid="My,WiFi"))
+        self.assertIn('"My,WiFi"', csv_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_validators.py
+++ b/tests/test_ui_validators.py
@@ -1,0 +1,90 @@
+# test_ui_validators.py — characterization tests for the pure input validators
+#
+# Run: python3 -m unittest discover -s tests -v
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from spoolsense_installer.ui import (
+    is_valid_hostname,
+    is_valid_ipv4,
+    validate_host,
+    validate_not_empty,
+    validate_port,
+    validate_ssid,
+    validate_url,
+)
+
+
+class Ipv4Test(unittest.TestCase):
+    def test_valid_addresses(self):
+        for addr in ("192.168.1.1", "10.0.0.0", "255.255.255.255", "0.0.0.0"):
+            self.assertTrue(is_valid_ipv4(addr), addr)
+
+    def test_invalid_addresses(self):
+        for addr in ("192.168.1", "192.168.1.1.1", "256.1.1.1", "1.2.3.04",
+                     "a.b.c.d", "", "192.168..1"):
+            self.assertFalse(is_valid_ipv4(addr), addr)
+
+
+class HostnameTest(unittest.TestCase):
+    def test_valid_hostnames(self):
+        for host in ("mqtt.local", "spoolman", "my-broker.example.com", "a"):
+            self.assertTrue(is_valid_hostname(host), host)
+
+    def test_invalid_hostnames(self):
+        for host in ("-bad.local", "bad-.local", "under_score", "a." + "b" * 64,
+                     "", "dot..dot"):
+            self.assertFalse(is_valid_hostname(host), host)
+
+
+class ValidateHostTest(unittest.TestCase):
+    def test_accepts_ip_and_hostname(self):
+        self.assertIsNone(validate_host("192.168.1.10"))
+        self.assertIsNone(validate_host("mqtt.local"))
+
+    def test_rejects_bad_values(self):
+        self.assertIsNotNone(validate_host(""))
+        self.assertIsNotNone(validate_host("999.1.1.1"))
+        self.assertIsNotNone(validate_host("bad_host"))
+
+
+class ValidatePortTest(unittest.TestCase):
+    def test_accepts_valid_range(self):
+        for port in ("1", "1883", "65535"):
+            self.assertIsNone(validate_port(port), port)
+
+    def test_rejects_invalid(self):
+        for port in ("0", "65536", "-1", "abc", ""):
+            self.assertIsNotNone(validate_port(port), port)
+
+
+class ValidateUrlTest(unittest.TestCase):
+    def test_accepts_http_https_with_port_and_path(self):
+        for url in ("http://spoolman.local:7912", "https://example.com",
+                    "http://192.168.1.5:7125/path"):
+            self.assertIsNone(validate_url(url), url)
+
+    def test_rejects_bad_urls(self):
+        for url in ("", "spoolman.local", "ftp://x", "http://", "http://bad_host",
+                    "http://host:notaport"):
+            self.assertIsNotNone(validate_url(url), url)
+
+
+class SimpleValidatorsTest(unittest.TestCase):
+    def test_not_empty(self):
+        self.assertIsNotNone(validate_not_empty(""))
+        self.assertIsNone(validate_not_empty("x"))
+
+    def test_ssid_length_limit(self):
+        self.assertIsNone(validate_ssid("MyWiFi"))
+        self.assertIsNone(validate_ssid("x" * 32))
+        self.assertIsNotNone(validate_ssid("x" * 33))
+        self.assertIsNotNone(validate_ssid(""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First tranche of the installer catch-up plan. Fixes the silent-failure bugs, closes two stale-bot-closed issues that were never implemented (#27, #30), and puts a regression floor (CI + 43 tests, up from 8) under future work.

### Fixed
- **Chip verification now fails closed** — aborts when `esptool flash-id` exits non-zero, times out, or output can't be parsed; previously verification was silently skipped and flashing proceeded. Chip-family matching is now exact: selecting `esp32dev` with an ESP32-S3 connected was previously accepted (`"esp32" in "esp32s3"` substring match).
- **Flash timeouts** exit with recovery guidance instead of a traceback; budget raised to 5 min for 16MB boards.
- **Removed the dead `mqtt_prefix` prompt/NVS key** — the pre-built firmware's topic prefix is compile-time (`UserConfig.h`) and the NVS key is never read; the prompt falsely implied custom prefixes work.
- Declining the config.yaml overwrite no longer skips systemd service creation; the manual-setup hint no longer references a deleted temp file.

### Added
- **Klipper macros for every setup type** (#27, #30) — `spoolsense.cfg` (ASSIGN_SPOOL/UPDATE_TAG) copied for all modes so filament deduction works everywhere; `spoolman_macros.cfg` for direct-toolhead setups, `toolhead_macros_example.cfg` for multi-tool. User-edited copies never overwritten. PRINT_END/UPDATE_TAG guidance printed.
- **Honest install summary** — per-step ✓/⚠/✗ outcomes instead of an unconditional "SpoolSense is installed!".
- **CI** — pytest + critical flake8 on Python 3.9/3.12 for every PR.

### Docs/meta
- README: Python 3.9+ (was 3.6+), all 4 boards listed, config mode + `--setup-fields` documented, Web Flasher cross-linked.
- CHANGELOG 1.3.0 entry (also retro-logs the #17/#33 robustness work); `__version__` fixed/bumped/shown in banner.
- `nvs_keys.csv` regenerated to match the generator; ESP32-C3 label aligned with spoolsense.org.
- GitHub Releases published for the previously tag-only v1.2.5/v1.2.6.

### Testing
- 43 tests pass locally (`python3 -m pytest tests/`), flake8 critical checks clean.
- Not yet exercised on real hardware — recommend one Pi + scanner pass before tagging v1.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer install progress reporting with per-step status and a more detailed completion summary.
  * Added support for additional ESP32 board variants and a Web Flasher-based setup path.

* **Bug Fixes**
  * Improved flashing reliability with longer timeouts, stricter board checks, and better error handling.
  * Removed an unnecessary MQTT topic prefix prompt and related setup entry.
  * Fixed installer behavior around config overwrites, service setup, and Spoolman field creation.

* **Chores**
  * Added continuous integration for automated tests and lint checks on pull requests.
  * Updated setup instructions and minimum Python version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->