### PR TITLE
Happy Hare parity with middleware v1.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@
 Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatically via the latest-release pin; the installer supports no older-version pinning for middleware, so this is a hard floor for HH setups).
 
 ### Added
+
 - **Happy Hare mobile flow** (middleware v1.8.6) — the web panel/mobile question is now offered for HH setups; `mobile.action: happy_hare_stage` lets a phone scan assign a tag to any gate. When enabled, the installer prompts for the MMU gate count (1–32) and writes `happy_hare.num_gates` (mandatory for this mobile action). The physical select-then-scan flow still needs no gate count, so declining mobile skips the prompt. No explicit `toolheads:` list is ever written for HH — the middleware derives `G0..G{n-1}` itself.
 
 ### Removed
+
 - **Dead Happy Hare Spoolman fields** — the installer no longer creates `spool.mmu_gate`/`spool.printer_name`: since v1.8.6 the middleware binds through Happy Hare's own `MMU_SPOOLMAN SPOOLID/GATE` command, and HH's `mmu_server` declares the fields it actually uses (`mmu_gate_map`, `printer_name`) on startup. The old direct-write `extra.mmu_gate` was never read by any Happy Hare version. Existing users' Spoolman fields are left untouched. `--setup-fields --happy-hare` is now a deprecated no-op.
 - **`happy_hare.printer_name` prompt and config key** — legacy as of v1.8.6 (tolerated but ignored; HH stamps its own printer identity during the bind). The HH block is now just `enabled` (+ optional `num_gates`).
 
 ### Fixed
+
 - HH setup notes now reference the real gate-selection command `MMU_SELECT GATE=N` (`MMU_SELECT_GATE` never existed) and describe the binding as going through `MMU_SPOOLMAN`.
 
 ---
@@ -19,6 +22,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.4.0] - 2026-07-06
 
 ### Added
+
 - **Preflight checks** — mode-aware host verification (esptool/NVS generator/GitHub/serial-group for scanner installs; git/venv-capability/systemd/writable paths for middleware) runs right after mode selection, aborting with the exact fix command before the user answers any questions.
 - **MQTT device-ID discovery** — the installer listens ~5s for the scanner's retained `spoolsense/<id>/availability`/`tag/state` topics and proposes real device IDs per scanner (labeled by lane/toolhead); `YOUR_DEVICE_ID` placeholders only remain when nothing is found or the user skips. Best-effort — broker problems degrade to the old flow.
 - `RELEASING.md` release checklist; stale-bot window lengthened with `accepted`/`tracking` label exemptions (five accepted issues were previously stale-closed unimplemented).
@@ -29,11 +33,13 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 - **Config backups** — `config.yaml` and `moonraker.conf` get a `.bak` copy before the installer modifies them.
 
 ### Fixed
+
 - **config.yaml generated with `yaml.safe_dump`** — passwords containing quotes/backslashes/`#` no longer corrupt the generated config (prompt validators remain as defense in depth).
 - URL validation rewritten on `urllib.parse` — bracketed IPv6 hosts accepted, malformed ports rejected consistently.
 - The multi-device port-selection prompt aborts cleanly on non-interactive stdin instead of looping forever; scanner install artifacts (including the credentials-bearing NVS binary) now use a private temp dir removed on exit.
 
 ### Changed
+
 - **Virtualenv everywhere (#21)** — middleware deps install into `~/SpoolSense/.venv` (systemd unit runs the venv python), the installer bootstraps its own venv, and `--break-system-packages` is gone. The `[update_manager spoolsense]` entry now includes `virtualenv`/`requirements` so Moonraker updates deps alongside the repo.
 - Library modules raise a typed `InstallerError` instead of calling `sys.exit()` — failures are testable and cleanup runs; the CLI entry point owns process exit.
 - The board prompt is generated from the single `BOARDS` table and the Moonraker `[spoolman]` block from one helper (previously three hand-synced copies).
@@ -43,6 +49,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.3.0] - 2026-07-05
 
 ### Added
+
 - **Happy Hare MMU setup type** (middleware #83) — new "Happy Hare MMU" option generates the `happy_hare_stage` scanner action and `happy_hare:` config block (enabled + printer_name), requires a Spoolman URL, and creates the `spool.mmu_gate` (integer) and `spool.printer_name` (text) extra fields the middleware PATCHes at bind time. `--setup-fields --happy-hare` re-creates them standalone.
 - **Moonraker `[update_manager spoolsense]` entry** (#16) — the installer offers to register the middleware with Moonraker's update manager (`channel: stable`), giving users a one-click update button in Mainsail/Fluidd that follows tagged releases.
 - **Middleware pinned to the latest release** — fresh installs check out the latest middleware release tag instead of whatever is on branch head (only when the clone is clean; never touches local commits). `--dev` opts back into branch head.
@@ -57,6 +64,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 - Installer version is now shown in the banner.
 
 ### Fixed
+
 - **Chip verification fails closed** — flashing now aborts if `esptool flash-id` exits non-zero, times out, or its output can't be parsed (previously verification was silently skipped and flashing proceeded). Chip family matching is exact: selecting `esp32dev` with an ESP32-S3 connected is now rejected (substring matching previously let it through).
 - **Flash timeout handled** — a hung flash now exits with guidance instead of a traceback; timeout raised from 2 to 5 minutes for 16MB boards.
 - **Removed the dead `mqtt_prefix` prompt/NVS key** — the pre-built firmware's MQTT topic prefix is compile-time (`spoolsense`) and the NVS key was never read; prompting for it falsely implied custom prefixes work.
@@ -65,6 +73,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 - `nvs_keys.csv` documentation regenerated to match the generator (namespace row fixed, `tft_driver` added, dead `mqtt_prefix` removed).
 
 ### Changed
+
 - README: corrected Python requirement (3.9+, was "3.6+"), documented all four supported boards (ESP32-C3 and S3-DevKitC-1 were missing), the Config-only mode, `--setup-fields`, and the Web Flasher alternative.
 - ESP32-C3 board label aligned with spoolsense.org: "ESP32-C3 SuperMini / DevKitM-1".
 - pip dependency installation now streams its output instead of running silently.
@@ -76,6 +85,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.6] - 2026-05-09
 
 ### Added
+
 - **ESP32-C3 board support** — `ESP32-C3-DevKitM-1 (4MB)` now selectable in the scanner board prompt. Matches the existing `esp32c3` PlatformIO env in the scanner firmware. Bootloader offset `0x0` (newer-ROM behavior, same as S3 family).
 
 ---
@@ -83,6 +93,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.5] - 2026-04-06
 
 ### Added
+
 - **Moonraker Spoolman config** — installer offers to add `[spoolman]` section to `moonraker.conf` when Spoolman is enabled. Required for real-time filament usage tracking on UID-only, TigerTag, and OpenSpool tags. Skips if already configured, handles missing file and permission errors gracefully. (#28)
 
 ---
@@ -90,11 +101,13 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.4] - 2026-03-28
 
 ### Added
+
 - NFC reader selection prompt (`pn5180` or `pn532`) during scanner setup. Written to NVS as `nfc_reader` string key.
 - `nfc_reader` entry added to `nvs_keys.csv` documentation.
 - Device ID reminder in post-flash output for all install modes.
 
 ### Fixed
+
 - Validator for NFC reader prompt now returns error string instead of bool (was rejecting valid inputs).
 
 ---
@@ -102,6 +115,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.3] - 2026-03-27
 
 ### Added
+
 - Keypad and Moonraker URL prompts during scanner setup. Writes `keypad_on` and `moonraker_url` to NVS.
 - Slicer integration prompt now shown for `afc_stage` users with hybrid setups (toolchanger + AFC). Explains that `publish_lane_data` enables ASSIGN_SPOOL macro watcher for direct toolheads alongside AFC lanes.
 
@@ -110,9 +124,11 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.2] - 2026-03-27
 
 ### Added
+
 - Prompts for optional hardware (16x2 I2C LCD display, status LED) during scanner setup. Answers are written to NVS (`lcd_on`, `led_on`) so the firmware enables only attached hardware on boot.
 
 ### Fixed
+
 - Deprecated `esptool.py` replaced with `esptool`, `write_flash` with `write-flash`, `flash_id` with `flash-id` to suppress deprecation warnings.
 
 ---
@@ -120,6 +136,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.1] - 2026-03-26
 
 ### Added
+
 - **Klipper macro copy** — when `toolhead_stage` is selected, copies `spoolsense.cfg` to `~/printer_data/config/` and reminds the user to add `[include spoolsense.cfg]` to their printer.cfg.
 
 ---
@@ -127,6 +144,7 @@ Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatic
 ## [1.2.0] - 2026-03-25
 
 ### Added
+
 - Slicer integration option — installer asks whether to enable `publish_lane_data` for Orca Slicer integration. Only shown for non-AFC setups. AFC and Happy Hare users are told they already have this feature.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.5.0] - Unreleased
+
+Happy Hare setups now target middleware v1.8.6+ (fresh installs get it automatically via the latest-release pin; the installer supports no older-version pinning for middleware, so this is a hard floor for HH setups).
+
+### Added
+- **Happy Hare mobile flow** (middleware v1.8.6) — the web panel/mobile question is now offered for HH setups; `mobile.action: happy_hare_stage` lets a phone scan assign a tag to any gate. When enabled, the installer prompts for the MMU gate count (1–32) and writes `happy_hare.num_gates` (mandatory for this mobile action). The physical select-then-scan flow still needs no gate count, so declining mobile skips the prompt. No explicit `toolheads:` list is ever written for HH — the middleware derives `G0..G{n-1}` itself.
+
+### Removed
+- **Dead Happy Hare Spoolman fields** — the installer no longer creates `spool.mmu_gate`/`spool.printer_name`: since v1.8.6 the middleware binds through Happy Hare's own `MMU_SPOOLMAN SPOOLID/GATE` command, and HH's `mmu_server` declares the fields it actually uses (`mmu_gate_map`, `printer_name`) on startup. The old direct-write `extra.mmu_gate` was never read by any Happy Hare version. Existing users' Spoolman fields are left untouched. `--setup-fields --happy-hare` is now a deprecated no-op.
+- **`happy_hare.printer_name` prompt and config key** — legacy as of v1.8.6 (tolerated but ignored; HH stamps its own printer identity during the bind). The HH block is now just `enabled` (+ optional `num_gates`).
+
+### Fixed
+- HH setup notes now reference the real gate-selection command `MMU_SELECT GATE=N` (`MMU_SELECT_GATE` never existed) and describe the binding as going through `MMU_SPOOLMAN`.
+
+---
+
 ## [1.4.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The installer asks a series of questions (WiFi, MQTT, board type, etc.) and then
    - **Toolchanger shared scanner** (`toolhead_stage`) — one scanner for all toolheads (klipper-toolchanger)
    - **Toolchanger per-toolhead** (`toolhead`) — one scanner per tool
    - **Single toolhead** (`single`) — one scanner, one extruder
-   - **Happy Hare MMU** (`happy_hare_stage`) — one shared scanner; scan a spool to bind it to the currently selected MMU gate (requires Happy Hare in pull mode and Spoolman)
+   - **Happy Hare MMU** (`happy_hare_stage`) — one shared scanner; select a gate (`MMU_SELECT GATE=N`), scan a spool, and the middleware binds it via Happy Hare's `MMU_SPOOLMAN SPOOLID/GATE` command. Optional mobile flow assigns tags to any gate from your phone. Requires Happy Hare in pull mode, Spoolman, and middleware ≥ 1.8.6 (installed automatically)
 3. **Klipper macros** — Copies the macros your setup needs to `~/printer_data/config/`: `spoolsense.cfg` (ASSIGN_SPOOL/UPDATE_TAG, all setups), `spoolman_macros.cfg` (direct-toolhead setups), and `toolhead_macros_example.cfg` (multi-tool setups). Add `UPDATE_TAG` to your `PRINT_END` macro for automatic filament tracking.
-4. **Spoolman** — Optionally creates extra fields in Spoolman (`nfc_id`, `tag_format`, `aspect`, `dry_temp`, `dry_time_hours`, plus `mmu_gate`/`printer_name` for Happy Hare) needed for full tag data tracking, and offers to add the `[spoolman]` section to `moonraker.conf`
+4. **Spoolman** — Optionally creates the scanner's extra fields in Spoolman (`nfc_id`, `tag_format`, `aspect`, `dry_temp`, `dry_time_hours`, `active_toolhead`, `nfc_link`) needed for full tag data tracking, and offers to add the `[spoolman]` section to `moonraker.conf`. (Happy Hare declares its own fields on startup — the installer doesn't create any for it.)
 5. **Updates** — Offers to register the middleware with Moonraker's update manager (`[update_manager spoolsense]`, stable channel) so updates show up in Mainsail/Fluidd. Fresh installs are pinned to the latest middleware release (use `--dev` for branch head).
 
 ### Install modes
@@ -40,10 +40,10 @@ The installer asks a series of questions (WiFi, MQTT, board type, etc.) and then
 ### Extra flags
 
 ```bash
-python3 install.py --setup-fields [--spoolman-url http://spoolman.local:7912] [--happy-hare]
+python3 install.py --setup-fields [--spoolman-url http://spoolman.local:7912]
 ```
 
-Re-creates just the required Spoolman extra fields (useful if Spoolman wasn't running during the initial install). `--happy-hare` also creates the `mmu_gate`/`printer_name` fields.
+Re-creates just the required Spoolman extra fields (useful if Spoolman wasn't running during the initial install). (`--happy-hare` is a deprecated no-op — Happy Hare declares its own fields since middleware v1.8.6.)
 
 ```bash
 python3 install.py --dev

--- a/install.py
+++ b/install.py
@@ -356,13 +356,14 @@ def _main() -> None:
 
     setup_type = (middleware_config or {}).get("setup_type", "")
 
-    # Happy Hare binding writes spool extras — Spoolman is mandatory there.
-    # Check the enabled flag too: the middleware-only settings collector fills
-    # spoolman_url even when Spoolman was declined.
+    # Happy Hare requires Spoolman: spools are identified by their Spoolman ID
+    # when binding gates via HH's MMU_SPOOLMAN command. Check the enabled flag
+    # too: the middleware-only settings collector fills spoolman_url even when
+    # Spoolman was declined.
     if setup_type == "happy_hare" and not (scanner_config.get("spoolman_on")
                                            and scanner_config.get("spoolman_url")):
-        print(f"\n  {C.YELLOW}Happy Hare requires Spoolman{C.RESET} — the middleware binds spools")
-        print("  to MMU gates by writing Spoolman extra fields.\n")
+        print(f"\n  {C.YELLOW}Happy Hare requires Spoolman{C.RESET} — spools are identified by their")
+        print("  Spoolman ID when binding gates via MMU_SPOOLMAN.\n")
         scanner_config["spoolman_url"] = ask("Spoolman URL", default="http://spoolman.local:7912",
                                              validate=validate_url)
         scanner_config["spoolman_on"] = 1

--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ the middleware (choose "Middleware only").
 Note: SpoolSense middleware must run on the printer host.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 import argparse
 import os
@@ -233,12 +233,18 @@ def print_completion_message(mode: str, scanner_config: dict, steps: list) -> No
 
 def run_setup_fields(spoolman_url: str, happy_hare: bool = False) -> int:
     """Re-run only Spoolman extra-field creation. Returns a process exit code."""
+    if happy_hare:
+        # Deprecated no-op kept so old invocations don't argparse-error:
+        # since middleware v1.8.6, Happy Hare's mmu_server declares its own
+        # Spoolman fields on startup — the installer no longer creates any.
+        print(f"\n  {C.YELLOW}Note:{C.RESET} --happy-hare is no longer needed — Happy Hare declares")
+        print("  its own Spoolman fields since middleware v1.8.6. Creating the")
+        print("  standard scanner fields only.")
     if not spoolman_url:
         spoolman_url = ask("Spoolman URL (e.g. http://localhost:7912)", validate=validate_url)
 
     print(f"\n{C.CYAN}── Spoolman Field Setup ───────────────{C.RESET}\n")
-    failed = setup_extra_fields(
-        spoolman_url, fields_for_setup("happy_hare" if happy_hare else ""))
+    failed = setup_extra_fields(spoolman_url, fields_for_setup(""))
     if failed:
         print_failed_fields_summary(spoolman_url, failed)
         return 1
@@ -264,7 +270,7 @@ def parse_args(argv=None) -> argparse.Namespace:
     parser.add_argument(
         "--happy-hare",
         action="store_true",
-        help="With --setup-fields: also create the Happy Hare fields (mmu_gate, printer_name).",
+        help="Deprecated no-op: Happy Hare declares its own Spoolman fields since middleware v1.8.6.",
     )
     parser.add_argument(
         "--dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spoolsense-installer"
-version = "1.4.0"
+version = "1.5.0"
 description = "Interactive CLI installer for the SpoolSense ecosystem — ESP32 scanner firmware + Klipper middleware"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/spoolsense_installer/config.py
+++ b/spoolsense_installer/config.py
@@ -145,17 +145,6 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     }
 
 
-# These values are interpolated into generated YAML (middleware.generate_config
-# uses f-strings, not a serializer) — reject anything that could break quoting.
-
-def validate_printer_name(value: str) -> Optional[str]:
-    if not value:
-        return "Cannot be empty"
-    if any(c in value for c in ('"', "\\")) or any(ord(c) < 32 for c in value):
-        return 'Cannot contain quotes, backslashes, or control characters'
-    return None
-
-
 def validate_toolhead_list(value: str) -> Optional[str]:
     names = [t.strip() for t in value.split(",")]
     if not names or any(not n for n in names):
@@ -184,18 +173,16 @@ def collect_middleware_config(low_spool_default: int = 100) -> Dict[str, Union[s
     })
 
     scanners: list[dict] = []
-    printer_name = ""
     toolheads: List[str] = []
     if setup_type == "happy_hare":
-        print(f"\n  {C.YELLOW}Note:{C.RESET} Happy Hare must run in {C.BOLD}pull mode{C.RESET} (spoolman_support: pull).")
-        print("  Workflow: select a gate (MMU_SELECT_GATE GATE=N), scan a tag,")
-        print("  and the middleware binds the spool to that gate in Spoolman.\n")
+        # Requires middleware >= 1.8.6 (binding via HH's MMU_SPOOLMAN command);
+        # fresh installs get it automatically via the latest-release pin.
+        print(f"\n  {C.YELLOW}Note:{C.RESET} Requires Happy Hare in {C.BOLD}pull mode{C.RESET} (spoolman_support: pull)")
+        print("  and SpoolSense middleware 1.8.6 or newer (installed automatically).")
+        print("  Workflow: select a gate (MMU_SELECT GATE=N), scan a tag, and the")
+        print("  middleware binds the spool via Happy Hare's MMU_SPOOLMAN command.\n")
         print(f"  {C.YELLOW}Note:{C.RESET} After flashing your scanner, find its device ID")
         print("  from the MQTT topic: spoolsense/<device_id>/tag/state\n")
-        # Written to each spool's extra.printer_name; Happy Hare uses it to
-        # identify this printer's spools when syncing from Spoolman.
-        printer_name = ask("Printer name (as Happy Hare knows it)",
-                           validate=validate_printer_name)
         scanners.append({"action": "happy_hare_stage"})
     elif setup_type == "afc_stage":
         print(f"\n  {C.YELLOW}Note:{C.RESET} After flashing your scanner, find its device ID")
@@ -237,14 +224,23 @@ def collect_middleware_config(low_spool_default: int = 100) -> Dict[str, Union[s
     low_spool_threshold = int(ask("Low-spool alert threshold (grams)",
                                   default=low_spool_default, validate=validate_grams))
 
-    # The middleware only accepts afc_stage/toolhead_stage/toolhead as the
-    # mobile action — there is no happy_hare mobile action, so don't offer
-    # the panel there (a generated fallback action would misroute HH scans).
-    mobile_enabled = False
-    if setup_type != "happy_hare":
-        print(f"\n  {C.YELLOW}Web config panel:{C.RESET} the middleware can serve a browser UI +")
-        print("  mobile REST API on port 5001 for editing config and mobile scans.\n")
-        mobile_enabled = ask_yesno("Enable the web config panel (port 5001)?", default=False)
+    print(f"\n  {C.YELLOW}Web config panel:{C.RESET} the middleware can serve a browser UI +")
+    print("  mobile REST API on port 5001 for editing config and mobile scans.")
+    if setup_type == "happy_hare":
+        print("  Mobile scans assign a tag to any MMU gate from your phone (v1.8.6+).")
+    print()
+    mobile_enabled = ask_yesno("Enable the web config panel (port 5001)?", default=False)
+
+    # The happy_hare_stage mobile action requires the gate count so the app
+    # can offer G0..G{n-1}; the middleware derives the gates itself. The
+    # physical select-then-scan flow works without it, so only ask when
+    # mobile is enabled.
+    num_gates = 0
+    if setup_type == "happy_hare" and mobile_enabled:
+        def validate_gates(value: str) -> Optional[str]:
+            return None if value.isdigit() and 1 <= int(value) <= 32 else "Must be 1-32"
+
+        num_gates = int(ask("Number of MMU gates", default=4, validate=validate_gates))
 
     publish_lane_data = False
     if setup_type == "afc_stage":
@@ -263,11 +259,11 @@ def collect_middleware_config(low_spool_default: int = 100) -> Dict[str, Union[s
     return {
         "setup_type": setup_type,
         "scanners": scanners,
-        "printer_name": printer_name,
         "toolheads": toolheads,
         "moonraker_url": moonraker_url,
         "low_spool_threshold": low_spool_threshold,
         "mobile_enabled": mobile_enabled,
+        "num_gates": num_gates,
         "publish_lane_data": publish_lane_data,
     }
 

--- a/spoolsense_installer/config.py
+++ b/spoolsense_installer/config.py
@@ -100,13 +100,13 @@ def collect_scanner_config() -> Dict[str, Union[str, int]]:
     if ask_yesno("Snapmaker U1 printer (direct mode)?", default=False):
         u1_on = 1
         u1_channel = int(ask("U1 material channel (0-3)", default=0,
-                             validate=lambda v: None if v.isdigit() and int(v) <= 3
+                             validate=lambda v: None if v.isdecimal() and int(v) <= 3
                              else "Must be 0-3"))
 
     print(f"\n{C.CYAN}── Behavior ───────────────────────────{C.RESET}\n")
 
     def validate_grams(value: str) -> Optional[str]:
-        return None if value.isdigit() else "Must be a non-negative number"
+        return None if value.isdecimal() else "Must be a non-negative number"
 
     low_spool_g = int(ask("Low-spool alert threshold (grams)", default=100,
                           validate=validate_grams))
@@ -219,7 +219,7 @@ def collect_middleware_config(low_spool_default: int = 100) -> Dict[str, Union[s
     moonraker_url = ask("Moonraker URL", default="http://localhost:7125", validate=validate_url)
 
     def validate_grams(value: str) -> Optional[str]:
-        return None if value.isdigit() else "Must be a non-negative number"
+        return None if value.isdecimal() else "Must be a non-negative number"
 
     low_spool_threshold = int(ask("Low-spool alert threshold (grams)",
                                   default=low_spool_default, validate=validate_grams))
@@ -238,7 +238,7 @@ def collect_middleware_config(low_spool_default: int = 100) -> Dict[str, Union[s
     num_gates = 0
     if setup_type == "happy_hare" and mobile_enabled:
         def validate_gates(value: str) -> Optional[str]:
-            return None if value.isdigit() and 1 <= int(value) <= 32 else "Must be 1-32"
+            return None if value.isdecimal() and 1 <= int(value) <= 32 else "Must be 1-32"
 
         num_gates = int(ask("Number of MMU gates", default=4, validate=validate_gates))
 

--- a/spoolsense_installer/middleware.py
+++ b/spoolsense_installer/middleware.py
@@ -58,18 +58,21 @@ def generate_config(scanner_config: dict, middleware_config: dict) -> str:
         "scanner_topic_prefix": "spoolsense",
     }
 
-    # Happy Hare pull-mode binding (middleware v1.7.3+): the middleware
-    # refuses to bind without enabled + printer_name.
+    # Happy Hare binding (middleware v1.8.6+): the middleware binds through
+    # HH's own MMU_SPOOLMAN SPOOLID/GATE command. printer_name is legacy —
+    # tolerated but ignored, HH stamps its own printer identity — so it is
+    # never written. num_gates is only needed for the mobile flow.
     if setup_type == "happy_hare":
-        cfg["happy_hare"] = {
-            "enabled": True,
-            "printer_name": middleware_config.get("printer_name", ""),
-        }
+        cfg["happy_hare"] = {"enabled": True}
+        if middleware_config.get("num_gates"):
+            cfg["happy_hare"]["num_gates"] = int(middleware_config["num_gates"])
 
     cfg["scanners"] = scanners_map
 
-    # Explicit toolheads list (issue #24) — the mobile app picker reads it
-    if toolheads:
+    # Explicit toolheads list (issue #24) — the mobile app picker reads it.
+    # Never for Happy Hare: the middleware derives gates G0..G{n-1} itself
+    # and rejects an explicit list for the happy_hare_stage mobile action.
+    if toolheads and setup_type != "happy_hare":
         cfg["toolheads"] = list(toolheads)
 
     # Web config panel / mobile REST API (middleware v1.7.0+, port 5001)
@@ -78,6 +81,10 @@ def generate_config(scanner_config: dict, middleware_config: dict) -> str:
             mobile = {"enabled": True, "action": "afc_stage"}
         elif setup_type == "toolhead_stage":
             mobile = {"enabled": True, "action": "toolhead_stage"}
+        elif setup_type == "happy_hare":
+            # v1.8.6+: phone scans assign a tag to any gate; requires
+            # happy_hare.num_gates and spoolman_url in this config
+            mobile = {"enabled": True, "action": "happy_hare_stage"}
         else:
             mobile = {"enabled": True, "action": "toolhead",
                       "toolhead": toolheads[0] if toolheads else "T0"}

--- a/spoolsense_installer/middleware.py
+++ b/spoolsense_installer/middleware.py
@@ -83,7 +83,12 @@ def generate_config(scanner_config: dict, middleware_config: dict) -> str:
             mobile = {"enabled": True, "action": "toolhead_stage"}
         elif setup_type == "happy_hare":
             # v1.8.6+: phone scans assign a tag to any gate; requires
-            # happy_hare.num_gates and spoolman_url in this config
+            # happy_hare.num_gates and spoolman_url in this config. Fail
+            # fast — the middleware rejects this action without a gate count.
+            gates = int(middleware_config.get("num_gates") or 0)
+            if not 1 <= gates <= 32:
+                print(f"  {C.RED}✗{C.RESET} Happy Hare mobile requires an MMU gate count (1-32)")
+                raise InstallerError
             mobile = {"enabled": True, "action": "happy_hare_stage"}
         else:
             mobile = {"enabled": True, "action": "toolhead",

--- a/spoolsense_installer/middleware.py
+++ b/spoolsense_installer/middleware.py
@@ -18,6 +18,28 @@ from .errors import InstallerError
 from .files import backup_file
 
 
+def _gate_count(value):
+    """Validated MMU gate count: None if absent, else an int in 1-32.
+
+    Anything else raises InstallerError — never emit a config the middleware
+    rejects, and never let int() tracebacks escape the CLI's error handling.
+    bool is an int subclass and floats truncate silently, so both are
+    rejected explicitly; strings must be plain decimal digits (isdecimal is
+    exactly the set int() accepts — isdigit is not: int('²') raises).
+    """
+    if value is None or value == "" or (not isinstance(value, bool) and value == 0):
+        return None
+    gates = None
+    if isinstance(value, int) and not isinstance(value, bool):
+        gates = value
+    elif isinstance(value, str) and value.isdecimal():
+        gates = int(value)
+    if gates is None or not 1 <= gates <= 32:
+        print(f"  {C.RED}✗{C.RESET} Invalid MMU gate count {value!r} — must be 1-32")
+        raise InstallerError
+    return gates
+
+
 def generate_config(scanner_config: dict, middleware_config: dict) -> str:
     """Generate middleware config.yaml from collected settings.
 
@@ -62,10 +84,12 @@ def generate_config(scanner_config: dict, middleware_config: dict) -> str:
     # HH's own MMU_SPOOLMAN SPOOLID/GATE command. printer_name is legacy —
     # tolerated but ignored, HH stamps its own printer identity — so it is
     # never written. num_gates is only needed for the mobile flow.
+    gates = _gate_count(middleware_config.get("num_gates")) \
+        if setup_type == "happy_hare" else None
     if setup_type == "happy_hare":
         cfg["happy_hare"] = {"enabled": True}
-        if middleware_config.get("num_gates"):
-            cfg["happy_hare"]["num_gates"] = int(middleware_config["num_gates"])
+        if gates:
+            cfg["happy_hare"]["num_gates"] = gates
 
     cfg["scanners"] = scanners_map
 
@@ -85,8 +109,7 @@ def generate_config(scanner_config: dict, middleware_config: dict) -> str:
             # v1.8.6+: phone scans assign a tag to any gate; requires
             # happy_hare.num_gates and spoolman_url in this config. Fail
             # fast — the middleware rejects this action without a gate count.
-            gates = int(middleware_config.get("num_gates") or 0)
-            if not 1 <= gates <= 32:
+            if not gates:
                 print(f"  {C.RED}✗{C.RESET} Happy Hare mobile requires an MMU gate count (1-32)")
                 raise InstallerError
             mobile = {"enabled": True, "action": "happy_hare_stage"}

--- a/spoolsense_installer/spoolman.py
+++ b/spoolsense_installer/spoolman.py
@@ -26,20 +26,18 @@ EXTRA_FIELDS = [
     ("spool", "nfc_link", "text", "nfc_link"),
 ]
 
-# Happy Hare binding (middleware v1.7.3+): the middleware PATCHes these onto
-# spools at scan time, and Spoolman rejects writes to undeclared fields with
-# HTTP 400 — so they must exist before the first bind. mmu_gate MUST be
-# integer (the middleware writes the gate number).
-HAPPY_HARE_FIELDS = [
-    ("spool", "mmu_gate", "integer", "MMU Gate"),
-    ("spool", "printer_name", "text", "Printer Name"),
-]
-
 
 def fields_for_setup(setup_type):
-    """The Spoolman extra fields a given middleware setup type requires."""
-    if setup_type == "happy_hare":
-        return EXTRA_FIELDS + HAPPY_HARE_FIELDS
+    """The Spoolman extra fields a given middleware setup type requires.
+
+    Every setup currently needs exactly the base scanner fields. Happy Hare
+    used to add mmu_gate/printer_name here, but since middleware v1.8.6 the
+    bind goes through HH's own MMU_SPOOLMAN command and HH's mmu_server
+    declares its own fields (mmu_gate_map, printer_name) on startup — the
+    installer-created spool.mmu_gate was never read by any HH version.
+    Existing users' fields are left alone; we only stop creating them.
+    Kept as a hook for future mode-specific fields (e.g. INDX, #38).
+    """
     return EXTRA_FIELDS
 
 
@@ -86,7 +84,7 @@ def setup_extra_fields(spoolman_url: str, fields: list = None) -> list:
     """Create extra fields in Spoolman for tag data enrichment.
 
     ``fields`` defaults to the base EXTRA_FIELDS; pass fields_for_setup(...) to
-    include mode-specific fields (e.g. Happy Hare's mmu_gate/printer_name).
+    include mode-specific fields.
 
     Returns a list of ``(entity_type, key)`` tuples that could NOT be created.
     An empty list means every field exists or was created successfully. Nothing
@@ -140,7 +138,7 @@ def print_failed_fields_summary(spoolman_url: str, failed: list) -> None:
     if not failed:
         return
 
-    field_meta = {(e, k): (ft, dn) for e, k, ft, dn in EXTRA_FIELDS + HAPPY_HARE_FIELDS}
+    field_meta = {(e, k): (ft, dn) for e, k, ft, dn in EXTRA_FIELDS}
     print(f"\n{C.RED}{C.BOLD}{'═' * 42}")
     print(f"  ⚠  Spoolman fields NOT created")
     print(f"{'═' * 42}{C.RESET}")

--- a/spoolsense_installer/ui.py
+++ b/spoolsense_installer/ui.py
@@ -85,7 +85,8 @@ def is_valid_ipv4(value: str) -> bool:
     if len(parts) != 4:
         return False
     for part in parts:
-        if not part or not part.isdigit():
+        # isdecimal, not isdigit: int() rejects digit-lookalikes like '²'
+        if not part or not part.isdecimal():
             return False
         # Reject leading zeros to avoid octal interpretation
         if len(part) > 1 and part[0] == "0":
@@ -128,7 +129,7 @@ def validate_host(value: str) -> Optional[str]:
 
 def validate_port(value: str) -> Optional[str]:
     """Validate a port number."""
-    if not value.isdigit():
+    if not value.isdecimal():
         return "Must be a number"
     port = int(value)
     # Port 0 is reserved; 65536+ overflows 16-bit field

--- a/tests/test_ui_validators.py
+++ b/tests/test_ui_validators.py
@@ -61,6 +61,13 @@ class ValidatePortTest(unittest.TestCase):
         for port in ("0", "65536", "-1", "abc", ""):
             self.assertIsNotNone(validate_port(port), port)
 
+    def test_unicode_digit_lookalikes_rejected_not_crash(self):
+        """'²'.isdigit() is True but int('²') raises — validators must
+        re-prompt on such input, never traceback."""
+        self.assertIsNotNone(validate_port("²²"))
+        self.assertFalse(is_valid_ipv4("19².1.1.1"))
+        self.assertIsNotNone(validate_host("19².1.1.1"))
+
 
 class ValidateUrlTest(unittest.TestCase):
     def test_accepts_http_https_with_port_and_path(self):

--- a/tests/test_week2_config.py
+++ b/tests/test_week2_config.py
@@ -91,6 +91,19 @@ class HappyHareMobileTest(unittest.TestCase):
         parsed = self._parsed(toolheads=["G0", "G1"])
         self.assertNotIn("toolheads", parsed)
 
+    def test_hh_mobile_without_gate_count_refused(self):
+        """num_gates is middleware-mandatory for the happy_hare_stage mobile
+        action — the generator must fail fast rather than emit a config the
+        middleware rejects at startup. (num_gates WITHOUT mobile stays legal:
+        it's only mandatory for the mobile action.)"""
+        from spoolsense_installer.errors import InstallerError
+        for bad_gates in (None, 0, 33):
+            cfg = hh_cfg(mobile_enabled=True)
+            if bad_gates is not None:
+                cfg["num_gates"] = bad_gates
+            with self.assertRaises(InstallerError, msg=repr(bad_gates)):
+                generate_config(scanner_cfg(), cfg)
+
 
 class ScannerFieldsV2Test(unittest.TestCase):
     def test_matches_firmware_required_fields_v2(self):

--- a/tests/test_week2_config.py
+++ b/tests/test_week2_config.py
@@ -10,9 +10,9 @@ import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from spoolsense_installer.config import validate_printer_name, validate_toolhead_list
+from spoolsense_installer.config import validate_toolhead_list
 from spoolsense_installer.middleware import generate_config
-from spoolsense_installer.spoolman import EXTRA_FIELDS, HAPPY_HARE_FIELDS, fields_for_setup
+from spoolsense_installer.spoolman import EXTRA_FIELDS, fields_for_setup
 
 
 def scanner_cfg(**overrides):
@@ -31,21 +31,65 @@ def middleware_cfg(**overrides):
     return cfg
 
 
+def hh_cfg(**overrides):
+    return middleware_cfg(setup_type="happy_hare",
+                          scanners=[{"action": "happy_hare_stage"}], **overrides)
+
+
 class HappyHareConfigTest(unittest.TestCase):
-    def test_happy_hare_setup_writes_integration_block(self):
-        """Middleware v1.7.3 requires happy_hare.enabled + printer_name and a
-        happy_hare_stage scanner action (middleware #83)."""
-        parsed = yaml.safe_load(generate_config(scanner_cfg(), middleware_cfg(
-            setup_type="happy_hare",
-            scanners=[{"action": "happy_hare_stage"}],
-            printer_name="MyVoron",
-        )))
+    """Middleware v1.8.6: binding goes through HH's own MMU_SPOOLMAN command;
+    printer_name is legacy (tolerated but ignored) and must not be written."""
+
+    def test_happy_hare_block_is_enabled_only(self):
+        parsed = yaml.safe_load(generate_config(scanner_cfg(), hh_cfg()))
         self.assertEqual(parsed["scanners"]["YOUR_DEVICE_ID"]["action"], "happy_hare_stage")
-        self.assertEqual(parsed["happy_hare"], {"enabled": True, "printer_name": "MyVoron"})
+        self.assertEqual(parsed["happy_hare"], {"enabled": True})
+
+    def test_legacy_printer_name_never_written(self):
+        """Even if an old collected config carries printer_name, drop it."""
+        parsed = yaml.safe_load(generate_config(scanner_cfg(),
+                                                hh_cfg(printer_name="MyVoron")))
+        self.assertNotIn("printer_name", parsed["happy_hare"])
+
+    def test_num_gates_written_when_provided(self):
+        parsed = yaml.safe_load(generate_config(scanner_cfg(), hh_cfg(num_gates=8)))
+        self.assertEqual(parsed["happy_hare"]["num_gates"], 8)
+
+    def test_num_gates_absent_when_not_provided(self):
+        """Physical select-then-scan needs no num_gates — don't write one."""
+        parsed = yaml.safe_load(generate_config(scanner_cfg(), hh_cfg()))
+        self.assertNotIn("num_gates", parsed["happy_hare"])
 
     def test_non_happy_hare_setup_has_no_block(self):
         parsed = yaml.safe_load(generate_config(scanner_cfg(), middleware_cfg()))
         self.assertNotIn("happy_hare", parsed)
+
+
+class HappyHareMobileTest(unittest.TestCase):
+    """v1.8.6 adds mobile.action: happy_hare_stage — phone scans assign a tag
+    to any gate. Middleware requires num_gates + spoolman_url for this action
+    and derives gates itself, so NO explicit toolheads list may be written."""
+
+    def _parsed(self, **overrides):
+        return yaml.safe_load(generate_config(
+            scanner_cfg(), hh_cfg(mobile_enabled=True, num_gates=4, **overrides)))
+
+    def test_mobile_action_is_happy_hare_stage(self):
+        parsed = self._parsed()
+        self.assertEqual(parsed["mobile"]["action"], "happy_hare_stage")
+        self.assertTrue(parsed["mobile"]["enabled"])
+        self.assertEqual(parsed["mobile"]["port"], 5001)
+        # mobile.toolhead is meaningless for this action
+        self.assertNotIn("toolhead", parsed["mobile"])
+
+    def test_num_gates_present_with_mobile(self):
+        self.assertEqual(self._parsed()["happy_hare"]["num_gates"], 4)
+
+    def test_no_explicit_toolheads_list_for_hh(self):
+        """The middleware derives G0..G{n-1} itself; an explicit toolheads:
+        list is rejected for HH mobile — never write one, even defensively."""
+        parsed = self._parsed(toolheads=["G0", "G1"])
+        self.assertNotIn("toolheads", parsed)
 
 
 class ScannerFieldsV2Test(unittest.TestCase):
@@ -67,23 +111,17 @@ class ScannerFieldsV2Test(unittest.TestCase):
 
 
 class ExtraFieldsSelectionTest(unittest.TestCase):
-    def test_happy_hare_fields_have_correct_types(self):
-        """mmu_gate must be integer, printer_name text — Spoolman rejects
-        writes to undeclared/mistyped fields with HTTP 400."""
-        fields = {(e, k): t for e, k, t, _ in HAPPY_HARE_FIELDS}
-        self.assertEqual(fields[("spool", "mmu_gate")], "integer")
-        self.assertEqual(fields[("spool", "printer_name")], "text")
+    def test_happy_hare_adds_no_extra_fields(self):
+        """Since middleware v1.8.6 the bind goes through HH's MMU_SPOOLMAN
+        command and HH's mmu_server declares its own Spoolman fields
+        (mmu_gate_map, printer_name) on startup. The old installer-created
+        spool.mmu_gate was never read by any HH version — stop creating it.
+        (Existing users' fields are left alone; we only stop creating.)"""
+        self.assertEqual(fields_for_setup("happy_hare"), EXTRA_FIELDS)
 
-    def test_happy_hare_setup_includes_hh_fields(self):
-        fields = fields_for_setup("happy_hare")
-        for f in EXTRA_FIELDS + HAPPY_HARE_FIELDS:
-            self.assertIn(f, fields)
-
-    def test_other_setups_exclude_hh_fields(self):
-        fields = fields_for_setup("single")
-        for f in HAPPY_HARE_FIELDS:
-            self.assertNotIn(f, fields)
-        self.assertEqual(fields, EXTRA_FIELDS)
+    def test_all_setups_get_base_fields(self):
+        for setup in ("single", "toolchanger", "afc_stage", "happy_hare", ""):
+            self.assertEqual(fields_for_setup(setup), EXTRA_FIELDS, setup)
 
 
 class LowSpoolThresholdTest(unittest.TestCase):
@@ -113,14 +151,6 @@ class ToolheadStageToolheadsTest(unittest.TestCase):
 
 
 class YamlSafeValidatorsTest(unittest.TestCase):
-    """printer_name and toolhead names are spliced into generated YAML via
-    f-strings — quotes/backslashes would silently corrupt config.yaml."""
-
-    def test_printer_name_rejects_yaml_breaking_chars(self):
-        self.assertIsNone(validate_printer_name("MyVoron 2.4"))
-        for bad in ('My "Voron"', "back\\slash", "", "line\nbreak"):
-            self.assertIsNotNone(validate_printer_name(bad), repr(bad))
-
     def test_toolhead_list_allows_simple_names_only(self):
         self.assertIsNone(validate_toolhead_list("T0,T1"))
         self.assertIsNone(validate_toolhead_list("T0, extruder_1"))

--- a/tests/test_week2_config.py
+++ b/tests/test_week2_config.py
@@ -91,6 +91,23 @@ class HappyHareMobileTest(unittest.TestCase):
         parsed = self._parsed(toolheads=["G0", "G1"])
         self.assertNotIn("toolheads", parsed)
 
+    def test_malformed_gate_counts_raise_installer_error_not_valueerror(self):
+        """int('garbage') must not traceback out of the generator — the CLI
+        only catches InstallerError. Floats truncate silently and bool is an
+        int subclass, so both are rejected rather than coerced."""
+        from spoolsense_installer.errors import InstallerError
+        for bad in ("garbage", "4.5", 4.9, True, [], "²"):
+            with self.assertRaises(InstallerError, msg=repr(bad)):
+                generate_config(scanner_cfg(), hh_cfg(mobile_enabled=True, num_gates=bad))
+            # Invalid values fail even without mobile — never silently dropped
+            with self.assertRaises(InstallerError, msg=repr(bad)):
+                generate_config(scanner_cfg(), hh_cfg(num_gates=bad))
+
+    def test_decimal_string_gate_count_accepted(self):
+        parsed = yaml.safe_load(generate_config(
+            scanner_cfg(), hh_cfg(mobile_enabled=True, num_gates="8")))
+        self.assertEqual(parsed["happy_hare"]["num_gates"], 8)
+
     def test_hh_mobile_without_gate_count_refused(self):
         """num_gates is middleware-mandatory for the happy_hare_stage mobile
         action — the generator must fail fast rather than emit a config the


### PR DESCRIPTION
## Summary

Middleware v1.8.6 changed the Happy Hare integration; three things this installer generates were stale. New installs pick up 1.8.6 automatically via the latest-release pin.

### 1. Stop creating the dead Spoolman fields
The installer-created `spool.mmu_gate` was never read by any Happy Hare version (HH uses `mmu_gate_map`); since 1.8.6 the middleware binds through HH's own `MMU_SPOOLMAN SPOOLID/GATE` command and HH's `mmu_server` declares its own fields on startup. `HAPPY_HARE_FIELDS` removed — existing users' Spoolman instances are untouched, we only stop creating. `--setup-fields --happy-hare` becomes a deprecated no-op (kept so old invocations don't argparse-error). Non-HH `EXTRA_FIELDS` unchanged.

### 2. Drop the printer_name requirement
Legacy as of 1.8.6 — tolerated but ignored; HH stamps its own printer identity during the bind. No prompt, never written (defensively dropped even if a stale collected config carries it). The HH block is now `enabled` + optional `num_gates`. `validate_printer_name` removed with its only caller.

### 3. Offer mobile for HH setups
`mobile.action: happy_hare_stage` is valid as of 1.8.6 — the web-panel question now includes HH like every other setup type. When accepted: prompt MMU gate count (1–32) → `happy_hare.num_gates` (middleware-mandatory for this action, along with `spoolman_url`, which HH setups already enforce). Declining mobile skips the prompt (physical select-then-scan needs no gate count). No explicit `toolheads:` list is ever written for HH — the middleware derives `G0..G{n-1}` and rejects one (covered by a defensive test).

### Version-compat decision
The installer pins middleware to the **latest release** and has no older-version pin flag, so there is nothing to gate on: HH setups declare a hard **≥ 1.8.6 floor**, stated in the setup prompt, README, and CHANGELOG.

### Docs
Binding description corrected to `MMU_SPOOLMAN SPOOLID/GATE`; gate selection corrected to `MMU_SELECT GATE=N` (`MMU_SELECT_GATE` never existed). README field list also updated to the current 7 scanner fields.

### Testing
111 tests green (12 HH tests rewritten/added: enabled-only block, legacy printer_name dropped, num_gates present/absent, mobile action, no-toolheads defense, fields parity). flake8 clean. Version bumped to 1.5.0 with an Unreleased CHANGELOG entry per RELEASING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Happy Hare mobile setup guidance, including phone scanning and MMU gate configuration.
  * Added support for configuring the number of Happy Hare MMU gates during setup.
  * Updated Happy Hare integration to use the `MMU_SPOOLMAN` binding flow.

* **Changes**
  * Removed creation of deprecated Happy Hare-specific Spoolman fields.
  * Deprecated the legacy Happy Hare printer-name option.
  * Updated installer and package version to 1.5.0.

* **Bug Fixes**
  * Improved validation for ports, IP addresses, and MMU gate counts, including Unicode input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->